### PR TITLE
Use BaseID instead of ID to declare the base def of a def

### DIFF
--- a/mod_dynamic_spawns/classes/spawnable.nut
+++ b/mod_dynamic_spawns/classes/spawnable.nut
@@ -79,7 +79,7 @@
 	{
 		foreach (key, value in _def)
 		{
-			if (key == "Class") continue;
+			if (key == "Class" || key == "BaseID") continue;
 			this[key] = value;
 		}
 	}

--- a/mod_dynamic_spawns/config.nut
+++ b/mod_dynamic_spawns/config.nut
@@ -84,19 +84,20 @@
 	if (_def instanceof _dataset.BaseClass)
 		return (clone _def).init();
 
-	if ("ID" in _def)
+	if ("BaseID" in _def)
 	{
-		local baseDef = _dataset.LookupMap[_def.ID];
+		local baseDef = _dataset.LookupMap[_def.BaseID];
 		::DynamicSpawns.__setClass(baseDef.Class, _def);
 		local ret = _def.Class(baseDef);
 		ret.copyDataFromDef(_def);
+		if (ret.ID == baseDef.ID) ret.ID += ret + "";
 		return ret.init();
 	}
 	else
 	{
 		::DynamicSpawns.__setClass(_dataset.BaseClass, _def);
 		local ret = _def.Class(_def);
-		ret.ID = ret + "";
+		if (ret.ID == "") ret.ID = ret + "";
 		return ret.init();
 	}
 }

--- a/mod_dynamic_spawns/data/parties/bandit_parties.nut
+++ b/mod_dynamic_spawns/data/parties/bandit_parties.nut
@@ -8,9 +8,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Bandit.Frontline", RatioMin = 0.00, RatioMax = 0.50},
-			{ ID = "Bandit.Ranged", RatioMin = 0.45, RatioMax = 1.00},
-			{ ID = "Bandit.Dogs", RatioMin = 0.00, RatioMax = 0.45}
+			{ BaseID = "Bandit.Frontline", RatioMin = 0.00, RatioMax = 0.50},
+			{ BaseID = "Bandit.Ranged", RatioMin = 0.45, RatioMax = 1.00},
+			{ BaseID = "Bandit.Dogs", RatioMin = 0.00, RatioMax = 0.45}
 		]
 	},
 	{
@@ -21,9 +21,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Bandit.Frontline", RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = true},
-			{ ID = "Bandit.Ranged", RatioMin = 0.00, RatioMax = 0.40},
-			{ ID = "Bandit.Dogs", RatioMin = 0.00, RatioMax = 0.20}
+			{ BaseID = "Bandit.Frontline", RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "Bandit.Ranged", RatioMin = 0.00, RatioMax = 0.40},
+			{ BaseID = "Bandit.Dogs", RatioMin = 0.00, RatioMax = 0.20}
 		]
 	},
 	{
@@ -34,10 +34,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Bandit.Frontline", RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = true},
-			{ ID = "Bandit.Ranged", RatioMin = 0.00, RatioMax = 0.35},
-			{ ID = "Bandit.Elite", RatioMin = 0.00, RatioMax = 0.35},
-			{ ID = "Bandit.Boss", RatioMin = 0.00, RatioMax = 0.11, StartingResourceMin = 150, DeterminesFigure = true},
+			{ BaseID = "Bandit.Frontline", RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "Bandit.Ranged", RatioMin = 0.00, RatioMax = 0.35},
+			{ BaseID = "Bandit.Elite", RatioMin = 0.00, RatioMax = 0.35},
+			{ BaseID = "Bandit.Boss", RatioMin = 0.00, RatioMax = 0.11, StartingResourceMin = 150, DeterminesFigure = true},
 		]
 	},
 	{
@@ -48,10 +48,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Bandit.Frontline", RatioMin = 0.50, RatioMax = 1.00},
-			{ ID = "Bandit.Ranged", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "Bandit.Elite", RatioMin = 0.00, RatioMax = 0.35},
-			{ ID = "Bandit.Boss", RatioMin = 0.0, RatioMax = 0.11, StartingResourceMin = 150}
+			{ BaseID = "Bandit.Frontline", RatioMin = 0.50, RatioMax = 1.00},
+			{ BaseID = "Bandit.Ranged", RatioMin = 0.00, RatioMax = 0.25},
+			{ BaseID = "Bandit.Elite", RatioMin = 0.00, RatioMax = 0.35},
+			{ BaseID = "Bandit.Boss", RatioMin = 0.0, RatioMax = 0.11, StartingResourceMin = 150}
 		]
 	},
 	{
@@ -62,10 +62,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Bandit.Frontline", RatioMin = 0.50, RatioMax = 1.00},
-			{ ID = "Bandit.Ranged", RatioMin = 0.00, RatioMax = 0.25},
-			{ ID = "Bandit.Elite", RatioMin = 0.00, RatioMax = 0.35},
-			{ ID = "Bandit.Boss", RatioMin = 0.01, RatioMax = 0.11}				// One boss is always guaranteed
+			{ BaseID = "Bandit.Frontline", RatioMin = 0.50, RatioMax = 1.00},
+			{ BaseID = "Bandit.Ranged", RatioMin = 0.00, RatioMax = 0.25},
+			{ BaseID = "Bandit.Elite", RatioMin = 0.00, RatioMax = 0.35},
+			{ BaseID = "Bandit.Boss", RatioMin = 0.01, RatioMax = 0.11}				// One boss is always guaranteed
 		]
 	},
 	{
@@ -76,7 +76,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Bandit.DisguisedDirewolf" }
+			{ BaseID = "Bandit.DisguisedDirewolf" }
 		]
 	}
 ]

--- a/mod_dynamic_spawns/data/parties/barbarian_parties.nut
+++ b/mod_dynamic_spawns/data/parties/barbarian_parties.nut
@@ -8,10 +8,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Barbarian.Frontline", 	RatioMin = 0.60, RatioMax = 1.00, DeterminesFigure = true },	// Vanilla: doesn't care about size
-			{ ID = "Barbarian.Support", 	RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 10, StartingResourceMin = 200 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
-			{ ID = "Barbarian.Dogs", 		RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5 },		// Vanilla: Start spawning in armies of 6+
-			{ ID = "Barbarian.Beastmaster", RatioMin = 0.00, RatioMax = 0.10, ReqPartySize = 5, StartingResourceMin = 195 }		// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
+			{ BaseID = "Barbarian.Frontline", 	RatioMin = 0.60, RatioMax = 1.00, DeterminesFigure = true },	// Vanilla: doesn't care about size
+			{ BaseID = "Barbarian.Support", 	RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 10, StartingResourceMin = 200 },			// Vanilla: Start spawning in armies of 15+; At 24+ a second drummer spawns
+			{ BaseID = "Barbarian.Dogs", 		RatioMin = 0.00, RatioMax = 0.15, ReqPartySize = 5 },		// Vanilla: Start spawning in armies of 6+
+			{ BaseID = "Barbarian.Beastmaster", RatioMin = 0.00, RatioMax = 0.10, ReqPartySize = 5, StartingResourceMin = 195 }		// Vanilla: Start spawning in armies of 7+ (singular case) but more like 9+
 		]
 	},
 	{
@@ -22,15 +22,15 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Barbarian.HunterFrontline", RatioMin = 0.60, RatioMax = 1.0, DeterminesFigure = true },
-			{ ID = "Barbarian.Dogs", 			RatioMin = 0.20, RatioMax = 0.45 }
+			{ BaseID = "Barbarian.HunterFrontline", RatioMin = 0.60, RatioMax = 1.0, DeterminesFigure = true },
+			{ BaseID = "Barbarian.Dogs", 			RatioMin = 0.20, RatioMax = 0.45 }
 		]
 	},
 	{
 		ID = "BarbarianKing",
 		DefaultFigure = "figure_wildman_06",
 		StaticUnitDefs = [
-			{ ID = "Barbarian.King" }
+			{ BaseID = "Barbarian.King" }
 		]
 	},
 
@@ -40,7 +40,7 @@ local parties = [
 		HardMin = 1,
 		HardMax = 1,
 		UnitBlockDefs = [
-			{ ID = "Barbarian.Unholds"}
+			{ BaseID = "Barbarian.Unholds"}
 		]
 	},
 	{
@@ -48,7 +48,7 @@ local parties = [
 		HardMin = 2,
 		HardMax = 2,
 		UnitBlockDefs = [
-			{ ID = "Barbarian.Unholds"}
+			{ BaseID = "Barbarian.Unholds"}
 		]
 	},
 	{
@@ -56,7 +56,7 @@ local parties = [
 		HardMin = 1,
 		HardMax = 1,
 		UnitBlockDefs = [
-			{ ID = "Barbarian.UnholdsFrost"}
+			{ BaseID = "Barbarian.UnholdsFrost"}
 		]
 	},
 	{
@@ -64,7 +64,7 @@ local parties = [
 		HardMin = 2,
 		HardMax = 2,
 		UnitBlockDefs = [
-			{ ID = "Barbarian.UnholdsFrost"}
+			{ BaseID = "Barbarian.UnholdsFrost"}
 		]
 	}
 ]

--- a/mod_dynamic_spawns/data/parties/beast_parties.nut
+++ b/mod_dynamic_spawns/data/parties/beast_parties.nut
@@ -7,7 +7,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Beast.Direwolves", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Beast.Direwolves", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -18,7 +18,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Beast.Ghouls", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Beast.Ghouls", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -29,7 +29,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Beast.Lindwurms", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Beast.Lindwurms", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -40,7 +40,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Beast.Unholds", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Beast.Unholds", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -51,7 +51,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Beast.UnholdsFrost", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Beast.UnholdsFrost", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -62,7 +62,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Beast.UnholdsBog", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Beast.UnholdsBog", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -73,7 +73,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Beast.Spiders", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Beast.Spiders", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -84,7 +84,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Beast.Alps", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Beast.Alps", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -95,7 +95,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Beast.Schrats", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Beast.Schrats", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -106,18 +106,18 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		StaticUnitDefs = [
-			{ ID = "Beast.Hexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
+			{ BaseID = "Beast.Hexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
 		],
 		UnitBlockDefs = [
-			{ ID = "Beast.HexenWithBodyguards", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 300 },
-			{ ID = "Beast.Spiders", RatioMin = 0.00, RatioMax = 1.00 },
-			{ ID = "Beast.Ghouls", RatioMin = 0.00, RatioMax = 1.00 },
-			{ ID = "Beast.Schrats", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
-			{ ID = "Beast.Unholds", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
-			{ ID = "Beast.UnholdsBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
-			{ ID = "Beast.Direwolves", RatioMin = 0.00, RatioMax = 1.00 },
-			{ ID = "Beast.HexenBandits", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
-			{ ID = "Beast.HexenBanditsRanged", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 200 }
+			{ BaseID = "Beast.HexenWithBodyguards", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 300 },
+			{ BaseID = "Beast.Spiders", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "Beast.Ghouls", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "Beast.Schrats", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
+			{ BaseID = "Beast.Unholds", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
+			{ BaseID = "Beast.UnholdsBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
+			{ BaseID = "Beast.Direwolves", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "Beast.HexenBandits", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
+			{ BaseID = "Beast.HexenBanditsRanged", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 200 }
 		]
 	},
 	{
@@ -128,16 +128,16 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		StaticUnitDefs = [
-			{ ID = "Beast.Hexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
+			{ BaseID = "Beast.Hexe" }    // This one has no Bodyguards, which is not perfect because sometimes the only Hexe spawns with bodyguards in vanilla
 		],
 		UnitBlockDefs = [
-			{ ID = "Beast.HexenNoSpiders", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 300 },
-			{ ID = "Beast.Ghouls", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 80 },
-			{ ID = "Beast.Schrats", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
-			{ ID = "Beast.Unholds", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
-			{ ID = "Beast.UnholdsBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
-			{ ID = "Beast.Direwolves", RatioMin = 0.00, RatioMax = 1.00 },
-			{ ID = "Beast.HexenBandits", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 }
+			{ BaseID = "Beast.HexenNoSpiders", RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 300 },
+			{ BaseID = "Beast.Ghouls", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 80 },
+			{ BaseID = "Beast.Schrats", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 300 },
+			{ BaseID = "Beast.Unholds", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 },
+			{ BaseID = "Beast.UnholdsBog", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 250 },
+			{ BaseID = "Beast.Direwolves", RatioMin = 0.00, RatioMax = 1.00 },
+			{ BaseID = "Beast.HexenBandits", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 200 }
 		]
 	},
 	{
@@ -148,7 +148,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Beast.HexenNoBodyguards", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Beast.HexenNoBodyguards", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 
@@ -161,7 +161,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Beast.Hyenas", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Beast.Hyenas", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -172,7 +172,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Beast.Serpents", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Beast.Serpents", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -183,7 +183,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Beast.SandGolems", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Beast.SandGolems", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	}
 
@@ -191,13 +191,13 @@ local parties = [
 	{
 		ID = "SpiderBodyguards",
 		UnitBlockDefs = [
-			{ ID = "Beast.SpiderBodyguards"}
+			{ BaseID = "Beast.SpiderBodyguards"}
 		]
 	},
 	{
 		ID = "DirewolfBodyguards",
 		UnitBlockDefs = [
-			{ ID = "Beast.DirewolfBodyguards"}
+			{ BaseID = "Beast.DirewolfBodyguards"}
 		]
 	}
 ]

--- a/mod_dynamic_spawns/data/parties/goblin_parties.nut
+++ b/mod_dynamic_spawns/data/parties/goblin_parties.nut
@@ -7,9 +7,9 @@ local parties = [
 		VisibilityMult = 1.0,		// Pure GoblinAmbusher groups have 0.75 here in vanilla
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Goblin.Frontline", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true},
-			{ ID = "Goblin.Ranged", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true},
-			{ ID = "Goblin.Flank", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 120, DeterminesFigure = true}		// Lategame GoblinRoamer only consist of Riders
+			{ BaseID = "Goblin.Frontline", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true},
+			{ BaseID = "Goblin.Ranged", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMax = 140, DeterminesFigure = true},
+			{ BaseID = "Goblin.Flank", RatioMin = 0.00, RatioMax = 1.00, StartingResourceMin = 120, DeterminesFigure = true}		// Lategame GoblinRoamer only consist of Riders
 		]
 	},
 	{	// Similar to GoblinRoamer except Scout sizes are capped in vanilla and they more mixed than Roamers. We have no cap in this implementation
@@ -20,9 +20,9 @@ local parties = [
 		VisibilityMult = 1.0,		// Parties that have no Rider have a value of 0.75 here in vanilla
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Goblin.Frontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ ID = "Goblin.Ranged", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ ID = "Goblin.Flank", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "Goblin.Frontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "Goblin.Ranged", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "Goblin.Flank", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
 		]
 	},
 	{
@@ -33,10 +33,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Goblin.Frontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true},
-			{ ID = "Goblin.Ranged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true},
-			{ ID = "Goblin.Flank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true},
-			{ ID = "Goblin.Boss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true}	// One boss is guaranteed at 250+ resources
+			{ BaseID = "Goblin.Frontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "Goblin.Ranged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "Goblin.Flank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true},
+			{ BaseID = "Goblin.Boss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true}	// One boss is guaranteed at 250+ resources
 	   ]
 	},
 	{
@@ -47,10 +47,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Goblin.Frontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true},
-			{ ID = "Goblin.Ranged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true},
-			{ ID = "Goblin.Flank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true},
-			{ ID = "Goblin.Boss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true}	// One boss is guaranteed at 250+ resources
+			{ BaseID = "Goblin.Frontline", RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "Goblin.Ranged", RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "Goblin.Flank", RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true},
+			{ BaseID = "Goblin.Boss", RatioMin = 0.01, RatioMax = 0.15, StartingResourceMin = 250, DeterminesFigure = true}	// One boss is guaranteed at 250+ resources
 		]
 	},
 	{
@@ -61,10 +61,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Goblin.Frontline", RatioMin = 0.35, RatioMax = 1.00},
-			{ ID = "Goblin.Ranged", RatioMin = 0.15, RatioMax = 0.50},
-			{ ID = "Goblin.Flank", RatioMin = 0.00, RatioMax = 0.35},
-			{ ID = "Goblin.Boss", RatioMin = 0.01, RatioMax = 0.11, DeterminesFigure = true}	// One boss is always guaranteed
+			{ BaseID = "Goblin.Frontline", RatioMin = 0.35, RatioMax = 1.00},
+			{ BaseID = "Goblin.Ranged", RatioMin = 0.15, RatioMax = 0.50},
+			{ BaseID = "Goblin.Flank", RatioMin = 0.00, RatioMax = 0.35},
+			{ BaseID = "Goblin.Boss", RatioMin = 0.01, RatioMax = 0.11, DeterminesFigure = true}	// One boss is always guaranteed
 		]
 	}
 ]

--- a/mod_dynamic_spawns/data/parties/greenskin_parties.nut
+++ b/mod_dynamic_spawns/data/parties/greenskin_parties.nut
@@ -7,14 +7,14 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Greenskin.GoblinsFoot", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
-			{ ID = "Goblin.Flank", 			RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
-			{ ID = "Goblin.Boss", 			RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 350, DeterminesFigure = true},
+			{ BaseID = "Greenskin.GoblinsFoot", RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "Goblin.Flank", 			RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "Goblin.Boss", 			RatioMin = 0.00, RatioMax = 0.13, StartingResourceMin = 350, DeterminesFigure = true},
 
-			{ ID = "Orc.Young", 			RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true},
-			{ ID = "Orc.Warrior", 			RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
-			{ ID = "Orc.Berserker", 		RatioMin = 0.00, RatioMax = 0.33, DeterminesFigure = true},
-			{ ID = "Orc.Boss", 				RatioMin = 0.00, RatioMax = 0.07, StartingResourceMin = 350, DeterminesFigure = true}
+			{ BaseID = "Orc.Young", 			RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true},
+			{ BaseID = "Orc.Warrior", 			RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true},
+			{ BaseID = "Orc.Berserker", 		RatioMin = 0.00, RatioMax = 0.33, DeterminesFigure = true},
+			{ BaseID = "Orc.Boss", 				RatioMin = 0.00, RatioMax = 0.07, StartingResourceMin = 350, DeterminesFigure = true}
 		]
 	}
 ]

--- a/mod_dynamic_spawns/data/parties/human_parties.nut
+++ b/mod_dynamic_spawns/data/parties/human_parties.nut
@@ -7,7 +7,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Human.CultistAmbush", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Human.CultistAmbush", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -18,7 +18,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
 		UnitBlockDefs = [
-			{ ID = "Human.Peasants", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Human.Peasants", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -29,7 +29,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
 		UnitBlockDefs = [
-			{ ID = "Human.PeasantsArmed", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Human.PeasantsArmed", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -40,7 +40,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.75,
 		UnitBlockDefs = [
-			{ ID = "Human.SouthernPeasants", RatioMin = 0.00, RatioMax = 1.00}
+			{ BaseID = "Human.SouthernPeasants", RatioMin = 0.00, RatioMax = 1.00}
 		]
 	},
 	{
@@ -51,9 +51,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Human.BountyHunter", RatioMin = 0.60, RatioMax = 1.00},
-			{ ID = "Human.BountyHunterRanged", RatioMin = 0.15, RatioMax = 0.30},
-			{ ID = "Human.Wardogs", RatioMin = 0.05, RatioMax = 0.15}
+			{ BaseID = "Human.BountyHunter", RatioMin = 0.60, RatioMax = 1.00},
+			{ BaseID = "Human.BountyHunterRanged", RatioMin = 0.15, RatioMax = 0.30},
+			{ BaseID = "Human.Wardogs", RatioMin = 0.05, RatioMax = 0.15}
 		]
 	},
 	{
@@ -64,10 +64,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Mercenary.Frontline", RatioMin = 0.60, RatioMax = 1.00},
-			{ ID = "Mercenary.Ranged", RatioMin = 0.12, RatioMax = 0.30},
-			{ ID = "Mercenary.Elite", RatioMin = 0.10, RatioMax = 0.25, ReqPartySize = 10 },    // Start spawning at 11+. Only exception is HedgeKnight which appears a in a group of 6 aswell
-			{ ID = "Human.Wardogs", RatioMin = 0.00, RatioMax = 0.12}
+			{ BaseID = "Mercenary.Frontline", RatioMin = 0.60, RatioMax = 1.00},
+			{ BaseID = "Mercenary.Ranged", RatioMin = 0.12, RatioMax = 0.30},
+			{ BaseID = "Mercenary.Elite", RatioMin = 0.10, RatioMax = 0.25, ReqPartySize = 10 },    // Start spawning at 11+. Only exception is HedgeKnight which appears a in a group of 6 aswell
+			{ BaseID = "Human.Wardogs", RatioMin = 0.00, RatioMax = 0.12}
 		]
 	},
 	{
@@ -78,9 +78,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Human.MilitiaFrontline",    RatioMin = 0.60, RatioMax = 1.00},
-			{ ID = "Human.MilitiaRanged",       RatioMin = 0.12, RatioMax = 0.35},
-			{ ID = "Human.MilitiaCaptain",      RatioMin = 0.09, RatioMax = 0.09, ReqPartySize = 12 }   // Vanilla: starts spawning in groups of 13+; Vanilla never spawns more than one
+			{ BaseID = "Human.MilitiaFrontline",    RatioMin = 0.60, RatioMax = 1.00},
+			{ BaseID = "Human.MilitiaRanged",       RatioMin = 0.12, RatioMax = 0.35},
+			{ BaseID = "Human.MilitiaCaptain",      RatioMin = 0.09, RatioMax = 0.09, ReqPartySize = 12 }   // Vanilla: starts spawning in groups of 13+; Vanilla never spawns more than one
 		]
 	},
 	{
@@ -91,12 +91,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
 		StaticUnitDefs = [
-			{ ID = "Human.CaravanDonkey" }
+			{ BaseID = "Human.CaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ ID = "Human.CaravanDonkeys",  RatioMin = 0.17, RatioMax = 0.20, ReqPartySize = 6 },      // Vanilla: Second Donkey starts spawning at 7+
-			{ ID = "Human.CaravanHands",    RatioMin = 0.35, RatioMax = 0.80},
-			{ ID = "Human.CaravanGuards",   RatioMin = 0.15, RatioMax = 0.55}
+			{ BaseID = "Human.CaravanDonkeys",  RatioMin = 0.17, RatioMax = 0.20, ReqPartySize = 6 },      // Vanilla: Second Donkey starts spawning at 7+
+			{ BaseID = "Human.CaravanHands",    RatioMin = 0.35, RatioMax = 0.80},
+			{ BaseID = "Human.CaravanGuards",   RatioMin = 0.15, RatioMax = 0.55}
 		]
 	},
 	{
@@ -107,12 +107,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
 		StaticUnitDefs = [
-			{ ID = "Human.CaravanDonkey" },      // In vanilla an escorted caravan can also have only a single Donkey. I chose to force 2 donkey every time instead
-			{ ID = "Human.CaravanDonkey" }
+			{ BaseID = "Human.CaravanDonkey" },      // In vanilla an escorted caravan can also have only a single Donkey. I chose to force 2 donkey every time instead
+			{ BaseID = "Human.CaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ ID = "Human.CaravanDonkeys",  RatioMin = 0.15, RatioMax = 0.35, ReqPartySize = 5 },   // Vanilla: Third donkey spawns at 6+
-			{ ID = "Human.CaravanHands",    RatioMin = 0.50, RatioMax = 1.00}
+			{ BaseID = "Human.CaravanDonkeys",  RatioMin = 0.15, RatioMax = 0.35, ReqPartySize = 5 },   // Vanilla: Third donkey spawns at 6+
+			{ BaseID = "Human.CaravanHands",    RatioMin = 0.50, RatioMax = 1.00}
 		]
 	}
 ]

--- a/mod_dynamic_spawns/data/parties/noble_parties.nut
+++ b/mod_dynamic_spawns/data/parties/noble_parties.nut
@@ -7,13 +7,13 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Noble.Frontline",   RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
-			{ ID = "Noble.Backline",    RatioMin = 0.01, RatioMax = 0.35 },
-			{ ID = "Noble.Ranged",      RatioMin = 0.01, RatioMax = 0.28 },
-			{ ID = "Noble.Flank",       RatioMin = 0.00, RatioMax = 0.12 },
-			{ ID = "Noble.Support",     RatioMin = 0.01, RatioMax = 0.07, DeterminesFigure = true, ReqPartySize = 10 },    // Vanilla: Bannerman start spawning at 14
-			{ ID = "Noble.Officer",     RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, ReqPartySize = 8 },    // Vanilla: First sergeant spawns at 9, next one 12 and then 15+; Second one spawns at 27+
-			{ ID = "Noble.Elite",       RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
+			{ BaseID = "Noble.Frontline",   RatioMin = 0.35, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "Noble.Backline",    RatioMin = 0.01, RatioMax = 0.35 },
+			{ BaseID = "Noble.Ranged",      RatioMin = 0.01, RatioMax = 0.28 },
+			{ BaseID = "Noble.Flank",       RatioMin = 0.00, RatioMax = 0.12 },
+			{ BaseID = "Noble.Support",     RatioMin = 0.01, RatioMax = 0.07, DeterminesFigure = true, ReqPartySize = 10 },    // Vanilla: Bannerman start spawning at 14
+			{ BaseID = "Noble.Officer",     RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, ReqPartySize = 8 },    // Vanilla: First sergeant spawns at 9, next one 12 and then 15+; Second one spawns at 27+
+			{ BaseID = "Noble.Elite",       RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
 		]
 	},
 	{
@@ -24,15 +24,15 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
 		StaticUnitDefs = [
-			{ ID = "Human.CaravanDonkey" }      // Makes it much easier to get a good ratio
+			{ BaseID = "Human.CaravanDonkey" }      // Makes it much easier to get a good ratio
 		],
 		UnitBlockDefs = [
-			{ ID = "Noble.Frontline",   RatioMin = 0.35, RatioMax = 1.00},
-			{ ID = "Noble.Backline",    RatioMin = 0.08, RatioMax = 0.35},
-			{ ID = "Noble.Ranged",      RatioMin = 0.08, RatioMax = 0.28},
-			{ ID = "Noble.Officer",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 10 },  // Vanilla: spawns at 12, at 15 and at 18 once respectively
-			{ ID = "Noble.Elite",       RatioMin = 0.00, RatioMax = 0.40 },
-			{ ID = "Noble.Donkeys",     RatioMin = 0.01, RatioMax = 0.08, ReqPartySize = 13 }   // Vanilla: second donkey spawns at 14+
+			{ BaseID = "Noble.Frontline",   RatioMin = 0.35, RatioMax = 1.00},
+			{ BaseID = "Noble.Backline",    RatioMin = 0.08, RatioMax = 0.35},
+			{ BaseID = "Noble.Ranged",      RatioMin = 0.08, RatioMax = 0.28},
+			{ BaseID = "Noble.Officer",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 10 },  // Vanilla: spawns at 12, at 15 and at 18 once respectively
+			{ BaseID = "Noble.Elite",       RatioMin = 0.00, RatioMax = 0.40 },
+			{ BaseID = "Noble.Donkeys",     RatioMin = 0.01, RatioMax = 0.08, ReqPartySize = 13 }   // Vanilla: second donkey spawns at 14+
 		]
 	}
 ]

--- a/mod_dynamic_spawns/data/parties/nomad_parties.nut
+++ b/mod_dynamic_spawns/data/parties/nomad_parties.nut
@@ -8,8 +8,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Nomad.Frontline",    RatioMin = 0.50, RatioMax = 0.80, DeterminesFigure = true },
-			{ ID = "Nomad.Ranged",       RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true }
+			{ BaseID = "Nomad.Frontline",    RatioMin = 0.50, RatioMax = 0.80, DeterminesFigure = true },
+			{ BaseID = "Nomad.Ranged",       RatioMin = 0.15, RatioMax = 0.50, DeterminesFigure = true }
 		]
 	},
 	{
@@ -20,10 +20,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Nomad.Frontline",       RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
-			{ ID = "Nomad.Ranged",          RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-			{ ID = "Nomad.Leader",          RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },  // They spawn as early as with 7 troops in vanilla. But 2 only start spawning in 23+
-			{ ID = "Nomad.Elite",           RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
+			{ BaseID = "Nomad.Frontline",       RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "Nomad.Ranged",          RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
+			{ BaseID = "Nomad.Leader",          RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },  // They spawn as early as with 7 troops in vanilla. But 2 only start spawning in 23+
+			{ BaseID = "Nomad.Elite",           RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
 		]
 	},
 	{
@@ -34,10 +34,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Nomad.Frontline",       RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
-			{ ID = "Nomad.Ranged",          RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
-			{ ID = "Nomad.Leader",          RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },    // Vanilla: spawn at 7+
-			{ ID = "Nomad.Elite",           RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
+			{ BaseID = "Nomad.Frontline",       RatioMin = 0.25, RatioMax = 1.00, DeterminesFigure = true },
+			{ BaseID = "Nomad.Ranged",          RatioMin = 0.00, RatioMax = 0.35, DeterminesFigure = true },
+			{ BaseID = "Nomad.Leader",          RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true },    // Vanilla: spawn at 7+
+			{ BaseID = "Nomad.Elite",           RatioMin = 0.00, RatioMax = 0.30, DeterminesFigure = true }
 		]
 	}
 ]

--- a/mod_dynamic_spawns/data/parties/orc_parties.nut
+++ b/mod_dynamic_spawns/data/parties/orc_parties.nut
@@ -7,8 +7,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Orc.Young", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ ID = "Orc.Warrior", 	RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150}
+			{ BaseID = "Orc.Young", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "Orc.Warrior", 	RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150}
 		]
 	},
 	{	// This is currently the same as OrcRoamers. I couldn't spot differences in Vanilla
@@ -19,8 +19,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Orc.Young", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ ID = "Orc.Warrior", 	RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150}
+			{ BaseID = "Orc.Young", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "Orc.Warrior", 	RatioMin = 0.00, RatioMax = 0.09, StartingResourceMin = 150}
 		]
 	},
 	{
@@ -31,11 +31,11 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Orc.Young", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true, StartingResourceMax = 250},
-			{ ID = "Orc.Young", 	RatioMin = 0.00, RatioMax = 0.65, DeterminesFigure = true, StartingResourceMin = 250},	// Lategame Parties will have less Young in them
-			{ ID = "Orc.Berserker", RatioMin = 0.00, RatioMax = 0.45, DeterminesFigure = true, StartingResourceMin = 125},
-			{ ID = "Orc.Warrior", 	RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true, StartingResourceMin = 150},
-			{ ID = "Orc.Boss", 		RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, StartingResourceMin = 210}		// Vanilla never spawns more than one Boss here
+			{ BaseID = "Orc.Young", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true, StartingResourceMax = 250},
+			{ BaseID = "Orc.Young", 	RatioMin = 0.00, RatioMax = 0.65, DeterminesFigure = true, StartingResourceMin = 250},	// Lategame Parties will have less Young in them
+			{ BaseID = "Orc.Berserker", RatioMin = 0.00, RatioMax = 0.45, DeterminesFigure = true, StartingResourceMin = 125},
+			{ BaseID = "Orc.Warrior", 	RatioMin = 0.00, RatioMax = 0.80, DeterminesFigure = true, StartingResourceMin = 150},
+			{ BaseID = "Orc.Boss", 		RatioMin = 0.00, RatioMax = 0.08, DeterminesFigure = true, StartingResourceMin = 210}		// Vanilla never spawns more than one Boss here
 		]
 	},
 	{
@@ -46,10 +46,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Orc.Young", 	RatioMin = 0.15, RatioMax = 1.00},
-			{ ID = "Orc.Berserker", RatioMin = 0.00, RatioMax = 0.45, StartingResourceMin = 125},
-			{ ID = "Orc.Warrior", 	RatioMin = 0.00, RatioMax = 0.80, StartingResourceMin = 150},
-			{ ID = "Orc.Boss", 		RatioMin = 0.00, RatioMax = 0.08, StartingResourceMin = 210}		// Vanilla never spawns more than one Boss here
+			{ BaseID = "Orc.Young", 	RatioMin = 0.15, RatioMax = 1.00},
+			{ BaseID = "Orc.Berserker", RatioMin = 0.00, RatioMax = 0.45, StartingResourceMin = 125},
+			{ BaseID = "Orc.Warrior", 	RatioMin = 0.00, RatioMax = 0.80, StartingResourceMin = 150},
+			{ BaseID = "Orc.Boss", 		RatioMin = 0.00, RatioMax = 0.08, StartingResourceMin = 210}		// Vanilla never spawns more than one Boss here
 		]
 	},
 	{
@@ -60,10 +60,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Orc.Young", 	RatioMin = 0.15, RatioMax = 0.80},
-			{ ID = "Orc.Berserker", RatioMin = 0.00, RatioMax = 0.50},
-			{ ID = "Orc.Warrior", 	RatioMin = 0.00, RatioMax = 0.80},
-			{ ID = "Orc.Boss", 		RatioMin = 0.01, RatioMax = 0.05}				// Vanilla never spawns more than one Boss here
+			{ BaseID = "Orc.Young", 	RatioMin = 0.15, RatioMax = 0.80},
+			{ BaseID = "Orc.Berserker", RatioMin = 0.00, RatioMax = 0.50},
+			{ BaseID = "Orc.Warrior", 	RatioMin = 0.00, RatioMax = 0.80},
+			{ BaseID = "Orc.Boss", 		RatioMin = 0.01, RatioMax = 0.05}				// Vanilla never spawns more than one Boss here
 		]
 	},
 	{	// In Vanilla these never spawn OrcYoungLOW but here they do
@@ -74,7 +74,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Orc.Young", 		DeterminesFigure = true }
+			{ BaseID = "Orc.Young", 		DeterminesFigure = true }
 		]
 	},
 	{	// In Vanilla these never spawn OrcYoungLOW but here they do
@@ -85,8 +85,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Orc.Young", 		DeterminesFigure = true },
-			{ ID = "Orc.Berserker", 	DeterminesFigure = true }
+			{ BaseID = "Orc.Young", 		DeterminesFigure = true },
+			{ BaseID = "Orc.Berserker", 	DeterminesFigure = true }
 		]
 	},
 	{
@@ -97,7 +97,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Orc.Berserker" }
+			{ BaseID = "Orc.Berserker" }
 		]
 	}
 ]

--- a/mod_dynamic_spawns/data/parties/scourge_faction.nut
+++ b/mod_dynamic_spawns/data/parties/scourge_faction.nut
@@ -7,13 +7,13 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Zombie.Frontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ ID = "Zombie.Ghost", 		RatioMin = 0.00, RatioMax = 0.12, ReqPartySize = 18},
-			{ ID = "Beast.Ghouls", 		RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
-			{ ID = "Undead.Frontline", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true},
-			{ ID = "Undead.Backline", 	RatioMin = 0.09, RatioMax = 0.35, DeterminesFigure = true},
-			{ ID = "Scourge.Boss", 		RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17, StartingResourceMin = 350},
-			{ ID = "Undead.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18},
+			{ BaseID = "Zombie.Frontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "Zombie.Ghost", 		RatioMin = 0.00, RatioMax = 0.12, ReqPartySize = 18},
+			{ BaseID = "Beast.Ghouls", 		RatioMin = 0.00, RatioMax = 0.20, ReqPartySize = 20},	// Vanilla does not spawn T3 Ghouls. We allow it here
+			{ BaseID = "Undead.Frontline", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "Undead.Backline", 	RatioMin = 0.09, RatioMax = 0.35, DeterminesFigure = true},
+			{ BaseID = "Scourge.Boss", 		RatioMin = 0.00, RatioMax = 0.12, DeterminesFigure = true, ReqPartySize = 17, StartingResourceMin = 350},
+			{ BaseID = "Undead.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18},
 		]
 	}
 ]

--- a/mod_dynamic_spawns/data/parties/southern_parties.nut
+++ b/mod_dynamic_spawns/data/parties/southern_parties.nut
@@ -9,12 +9,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Southern.Frontline",    RatioMin = 0.50, RatioMax = 0.90, DeterminesFigure = true},			// Vanilla: doesn't care about size
-			{ ID = "Southern.Backline",     RatioMin = 0.10, RatioMax = 0.40 },				// Vanilla: doesn't care about size
-			{ ID = "Southern.Ranged",       RatioMin = 0.00, RatioMax = 0.30 },		// Vanilla: doesn't care about size
-			{ ID = "Southern.Assassins",    RatioMin = 0.00, RatioMax = 0.13, ReqPartySize = 7 },		// Vanilla: Start spawning at 8+
-			{ ID = "Southern.Officers",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 5, DeterminesFigure = true},		// Vanilla: Start spawning at 15+
-			{ ID = "Southern.Siege",        RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 16 }		// Vanilla: Start spawning at 19+
+			{ BaseID = "Southern.Frontline",    RatioMin = 0.50, RatioMax = 0.90, DeterminesFigure = true},			// Vanilla: doesn't care about size
+			{ BaseID = "Southern.Backline",     RatioMin = 0.10, RatioMax = 0.40 },				// Vanilla: doesn't care about size
+			{ BaseID = "Southern.Ranged",       RatioMin = 0.00, RatioMax = 0.30 },		// Vanilla: doesn't care about size
+			{ BaseID = "Southern.Assassins",    RatioMin = 0.00, RatioMax = 0.13, ReqPartySize = 7 },		// Vanilla: Start spawning at 8+
+			{ BaseID = "Southern.Officers",     RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 5, DeterminesFigure = true},		// Vanilla: Start spawning at 15+
+			{ BaseID = "Southern.Siege",        RatioMin = 0.00, RatioMax = 0.07, ReqPartySize = 16 }		// Vanilla: Start spawning at 19+
 		]
 	},
 	{
@@ -25,14 +25,14 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
 		StaticUnitDefs = [
-			{ ID = "Southern.CaravanDonkey" }
+			{ BaseID = "Southern.CaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ ID = "Southern.Frontline",        RatioMin = 0.15, RatioMax = 1.00 },
-			{ ID = "Southern.Slaves",           RatioMin = 0.00, RatioMax = 0.25 },
-			{ ID = "Southern.Backline",         RatioMin = 0.10, RatioMax = 0.40 },
-			{ ID = "Southern.Officers",         RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 14 },
-			{ ID = "Southern.CaravanDonkeys",   RatioMin = 0.01, RatioMax = 0.12, ReqPartySize = 14 }   // Vanilla: Second starts spawning at 14, then 16+
+			{ BaseID = "Southern.Frontline",        RatioMin = 0.15, RatioMax = 1.00 },
+			{ BaseID = "Southern.Slaves",           RatioMin = 0.00, RatioMax = 0.25 },
+			{ BaseID = "Southern.Backline",         RatioMin = 0.10, RatioMax = 0.40 },
+			{ BaseID = "Southern.Officers",         RatioMin = 0.00, RatioMax = 0.08, ReqPartySize = 14 },
+			{ BaseID = "Southern.CaravanDonkeys",   RatioMin = 0.01, RatioMax = 0.12, ReqPartySize = 14 }   // Vanilla: Second starts spawning at 14, then 16+
 		]
 		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
 	},
@@ -44,12 +44,12 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.25,
 		StaticUnitDefs = [
-			{ ID = "Southern.CaravanDonkey" }
+			{ BaseID = "Southern.CaravanDonkey" }
 		],
 		UnitBlockDefs = [
-			{ ID = "Southern.Frontline",        RatioMin = 0.35, RatioMax = 1.00 },
-			// { ID = "Southern.Slaves",           RatioMin = 0.00, RatioMax = 0.25 },     // This is new. I find Slaves seen as a trade good a nice touch for player escorted southern caravans
-			{ ID = "Southern.CaravanDonkeys",   RatioMin = 0.35, RatioMax = 0.50, ReqPartySize = 3 }
+			{ BaseID = "Southern.Frontline",        RatioMin = 0.35, RatioMax = 1.00 },
+			// { BaseID = "Southern.Slaves",           RatioMin = 0.00, RatioMax = 0.25 },     // This is new. I find Slaves seen as a trade good a nice touch for player escorted southern caravans
+			{ BaseID = "Southern.CaravanDonkeys",   RatioMin = 0.35, RatioMax = 0.50, ReqPartySize = 3 }
 		]
 		// In Vanilla this party is also able to spawn just with mercenaries. But this is so rare that I chose to not try to mirror that behavior here
 	},
@@ -61,7 +61,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Southern.Slaves",           RatioMin = 0.00, RatioMax = 1.00 }
+			{ BaseID = "Southern.Slaves",           RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -72,7 +72,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Human.Slaves",           RatioMin = 0.00, RatioMax = 1.00 }
+			{ BaseID = "Human.Slaves",           RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 	{
@@ -83,7 +83,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Southern.Assassins",           RatioMin = 0.00, RatioMax = 1.00 }
+			{ BaseID = "Southern.Assassins",           RatioMin = 0.00, RatioMax = 1.00 }
 		]
 	},
 
@@ -93,7 +93,7 @@ local parties = [
 		HardMin = 2,
 		HardMax = 2,
 		UnitBlockDefs = [
-			{ ID = "Southern.Engineer"}
+			{ BaseID = "Southern.Engineer"}
 		]
 	}
 ]

--- a/mod_dynamic_spawns/data/parties/undead_faction.nut
+++ b/mod_dynamic_spawns/data/parties/undead_faction.nut
@@ -7,10 +7,10 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Undead.Frontline", 	RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = true},
-			{ ID = "Undead.Backline", 	RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true, ReqPartySize = 8},
-			{ ID = "Undead.Boss", 		RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true, ReqPartySize = 15, StartingResourceMin = 225},
-			{ ID = "Undead.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18, StartingResourceMin = 225},
+			{ BaseID = "Undead.Frontline", 	RatioMin = 0.50, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "Undead.Backline", 	RatioMin = 0.00, RatioMax = 0.50, DeterminesFigure = true, ReqPartySize = 8},
+			{ BaseID = "Undead.Boss", 		RatioMin = 0.00, RatioMax = 0.10, DeterminesFigure = true, ReqPartySize = 15, StartingResourceMin = 225},
+			{ BaseID = "Undead.Vampire", 	RatioMin = 0.00, RatioMax = 0.11, DeterminesFigure = true, ReqPartySize = 18, StartingResourceMin = 225},
 		]
 	},
 	{
@@ -21,7 +21,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Undead.Vampire", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "Undead.Vampire", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
 		]
 	},
 	{
@@ -32,8 +32,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Undead.Frontline", 	RatioMin = 0.60, RatioMax = 1.00},		// In Vanilla only LightSkeletons spawn here
-			{ ID = "Undead.Vampire", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "Undead.Frontline", 	RatioMin = 0.60, RatioMax = 1.00},		// In Vanilla only LightSkeletons spawn here
+			{ BaseID = "Undead.Vampire", 	RatioMin = 0.15, RatioMax = 1.00, DeterminesFigure = true}
 		]
 	},
 

--- a/mod_dynamic_spawns/data/parties/zombies_faction.nut
+++ b/mod_dynamic_spawns/data/parties/zombies_faction.nut
@@ -7,7 +7,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
 		UnitBlockDefs = [
-			{ ID = "Zombie.Frontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
+			{ BaseID = "Zombie.Frontline", 	RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true}
 		]
 	},
 	{
@@ -18,7 +18,7 @@ local parties = [
 		VisibilityMult = 0.75,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Zombie.Ghost" }
+			{ BaseID = "Zombie.Ghost" }
 		]
 	},
 	{
@@ -29,8 +29,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
 		UnitBlockDefs = [
-			{ ID = "Zombie.Frontline", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ ID = "Beast.GhoulLowOnly", 	RatioMin = 0.10, RatioMax = 0.30},
+			{ BaseID = "Zombie.Frontline", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "Beast.GhoulLowOnly", 	RatioMin = 0.10, RatioMax = 0.30},
 		]
 	},
 	{
@@ -41,8 +41,8 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
 		UnitBlockDefs = [
-			{ ID = "Zombie.Frontline", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
-			{ ID = "Zombie.Ghost", 			RatioMin = 0.12, RatioMax = 0.35},
+			{ BaseID = "Zombie.Frontline", 		RatioMin = 0.00, RatioMax = 1.00, DeterminesFigure = true},
+			{ BaseID = "Zombie.Ghost", 			RatioMin = 0.12, RatioMax = 0.35},
 		]
 	},
 	{
@@ -53,9 +53,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Zombie.Frontline", 						RatioMin = 0.50, RatioMax = 1.00},
-			{ ID = "Zombie.Ghost", 							RatioMin = 0.00, RatioMax = 0.20},
-			{ ID = "Zombie.NecromancerWithBodyguards", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
+			{ BaseID = "Zombie.Frontline", 						RatioMin = 0.50, RatioMax = 1.00},
+			{ BaseID = "Zombie.Ghost", 							RatioMin = 0.00, RatioMax = 0.20},
+			{ BaseID = "Zombie.NecromancerWithBodyguards", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
 		]
 	},
 	{
@@ -66,9 +66,9 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 1.0,
 		UnitBlockDefs = [
-			{ ID = "Zombie.Southern", 					RatioMin = 0.65, RatioMax = 1.00},
-			{ ID = "Zombie.NecromancerWithNomads", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
-			{ ID = "Zombie.Elite", 						RatioMin = 0.00, RatioMax = 0.12, StartingResourceMin = 200},
+			{ BaseID = "Zombie.Southern", 					RatioMin = 0.65, RatioMax = 1.00},
+			{ BaseID = "Zombie.NecromancerWithNomads", 		RatioMin = 0.04, RatioMax = 0.09, DeterminesFigure = true},
+			{ BaseID = "Zombie.Elite", 						RatioMin = 0.00, RatioMax = 0.12, StartingResourceMin = 200},
 		]
 	},
 	{	// Only un-armored zombies
@@ -79,7 +79,7 @@ local parties = [
 		VisibilityMult = 1.0,
 		VisionMult = 0.8,
 		UnitBlockDefs = [
-			{ ID = "Zombie.Light" }
+			{ BaseID = "Zombie.Light" }
 		]
 	},
 
@@ -88,30 +88,30 @@ local parties = [
 		ID = "SubPartyYeoman",
 		HardMin = 1,
 		StaticUnitDefs = [
-			{ ID = "Undead.YeomanBodyguard" }
+			{ BaseID = "Undead.YeomanBodyguard" }
 		]
 	},
 	{
 		ID = "SubPartyKnight",
 		HardMin = 1,
 		StaticUnitDefs = [
-			{ ID = "Undead.FallenHeroBodyguard" }
+			{ BaseID = "Undead.FallenHeroBodyguard" }
 		]
 	},
 	{
 		ID = "SubPartyYeomanKnight",
 		HardMin = 2,
 		StaticUnitDefs = [
-			{ ID = "Undead.YeomanBodyguard" },
-			{ ID = "Undead.FallenHeroBodyguard" }
+			{ BaseID = "Undead.YeomanBodyguard" },
+			{ BaseID = "Undead.FallenHeroBodyguard" }
 		]
 	},
 	{
 		ID = "SubPartyKnightKnight",
 		HardMin = 2,
 		StaticUnitDefs = [
-			{ ID = "Undead.FallenHeroBodyguard" },
-			{ ID = "Undead.FallenHeroBodyguard" }
+			{ BaseID = "Undead.FallenHeroBodyguard" },
+			{ BaseID = "Undead.FallenHeroBodyguard" }
 		]
 	},
 	{	// The amount is set from outside

--- a/mod_dynamic_spawns/data/unitblocks/bandit_blocks.nut
+++ b/mod_dynamic_spawns/data/unitblocks/bandit_blocks.nut
@@ -2,34 +2,34 @@ local unitBlocks = [
 	{
 		ID = "Bandit.Frontline",
 		UnitDefs = [
-			{ ID = "Bandit.Thug", StartingResourceMax = 320 }, 	// Thugs stop spawning alltogether by the time that Hedgeknights appear
-			{ ID = "Bandit.RaiderLOW", StartingResourceMin = 100, StartingResourceMax = 175 },
-			{ ID = "Bandit.Raider", StartingResourceMin = 175, }]
+			{ BaseID = "Bandit.Thug", StartingResourceMax = 320 }, 	// Thugs stop spawning alltogether by the time that Hedgeknights appear
+			{ BaseID = "Bandit.RaiderLOW", StartingResourceMin = 100, StartingResourceMax = 175 },
+			{ BaseID = "Bandit.Raider", StartingResourceMin = 175, }]
 	},
 	{
 		ID = "Bandit.Ranged",
-		UnitDefs = [{ ID = "Bandit.Poacher" }, { ID = "Bandit.Marksman", StartingResourceMin = 100 }]
+		UnitDefs = [{ BaseID = "Bandit.Poacher" }, { BaseID = "Bandit.Marksman", StartingResourceMin = 100 }]
 	},
 	{
 		ID = "Bandit.Dogs",
-		UnitDefs = [{ ID = "Human.Wardog" }]
+		UnitDefs = [{ BaseID = "Human.Wardog" }]
 	},
 	{
 		ID = "Bandit.Elite",
 		StartingResourceMin = 320,
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { ID = "Human.MasterArcher" }],
-			[1, { ID = "Human.HedgeKnight" }],
-			[1, { ID = "Human.Swordmaster" }]
+			[1, { BaseID = "Human.MasterArcher" }],
+			[1, { BaseID = "Human.HedgeKnight" }],
+			[1, { BaseID = "Human.Swordmaster" }]
 		])
 	},
 	{
 		ID = "Bandit.Boss",
-		UnitDefs = [{ ID = "Bandit.Leader" }]
+		UnitDefs = [{ BaseID = "Bandit.Leader" }]
 	},
 	{
 		ID = "Bandit.DisguisedDirewolf",
-		UnitDefs = [{ ID = "Bandit.RaiderWolf" }]
+		UnitDefs = [{ BaseID = "Bandit.RaiderWolf" }]
 	}
 ]
 

--- a/mod_dynamic_spawns/data/unitblocks/barbarian_blocks.nut
+++ b/mod_dynamic_spawns/data/unitblocks/barbarian_blocks.nut
@@ -1,35 +1,35 @@
 local unitBlocks = [
 	{
 		ID = "Barbarian.Frontline",
-		UnitDefs = [{ ID = "Barbarian.Thrall" }, { ID = "Barbarian.Marauder", StartingResourceMin = 125 }, { ID = "Barbarian.Chosen", StartingResourceMin = 200 }]
+		UnitDefs = [{ BaseID = "Barbarian.Thrall" }, { BaseID = "Barbarian.Marauder", StartingResourceMin = 125 }, { BaseID = "Barbarian.Chosen", StartingResourceMin = 200 }]
 	},
 	{
 		ID = "Barbarian.Support",
-		UnitDefs = [{ ID = "Barbarian.Drummer" }],
+		UnitDefs = [{ BaseID = "Barbarian.Drummer" }],
 		StartingResourceMin = 200	// In Vanilla they start appearing in a group of 210 cost alongside 15 thralls
 
 	},
 	{
 		ID = "Barbarian.Dogs",
-		UnitDefs = [{ ID = "Barbarian.Warhound" }]
+		UnitDefs = [{ BaseID = "Barbarian.Warhound" }]
 	},
 	{
 		ID = "Barbarian.Beastmaster",
-		UnitDefs = [{ ID = "Barbarian.BeastmasterU" }, { ID = "Barbarian.BeastmasterF" }, { ID = "Barbarian.BeastmasterUU" }, { ID = "Barbarian.BeastmasterFF" }],
+		UnitDefs = [{ BaseID = "Barbarian.BeastmasterU" }, { BaseID = "Barbarian.BeastmasterF" }, { BaseID = "Barbarian.BeastmasterUU" }, { BaseID = "Barbarian.BeastmasterFF" }],
 		StartingResourceMin = 200	// In Vanilla they appear in a group of 195 cost
 	},
 	{
 		ID = "Barbarian.HunterFrontline",
-		UnitDefs = [{ ID = "Barbarian.Thrall" }]
+		UnitDefs = [{ BaseID = "Barbarian.Thrall" }]
 	},
 
 	{
 		ID = "Barbarian.Unholds",
-		UnitDefs = [{ ID = "Barbarian.Unhold" }]
+		UnitDefs = [{ BaseID = "Barbarian.Unhold" }]
 	},
 	{
 		ID = "Barbarian.UnholdsFrost",
-		UnitDefs = [{ ID = "Barbarian.UnholdFrost" }]
+		UnitDefs = [{ BaseID = "Barbarian.UnholdFrost" }]
 	}
 ]
 

--- a/mod_dynamic_spawns/data/unitblocks/beast_blocks.nut
+++ b/mod_dynamic_spawns/data/unitblocks/beast_blocks.nut
@@ -2,88 +2,88 @@ local unitBlocks = [
 	// Purebred Beasts
 	{
 		ID = "Beast.Direwolves",
-		UnitDefs = [{ ID = "Beast.Direwolf" }, { ID = "Beast.DirewolfHIGH" }]
+		UnitDefs = [{ BaseID = "Beast.Direwolf" }, { BaseID = "Beast.DirewolfHIGH" }]
 	},
 	{
 		ID = "Beast.GhoulLowOnly",
-		UnitDefs = [{ ID = "Beast.GhoulLOW" }]
+		UnitDefs = [{ BaseID = "Beast.GhoulLOW" }]
 	},
 	{
 		ID = "Beast.Ghouls",
-		UnitDefs = [{ ID = "Beast.GhoulLOW" }, { ID = "Beast.Ghoul", StartingResourceMin = 125 }, { ID = "Beast.GhoulHIGH", StartingResourceMin = 175 }]
+		UnitDefs = [{ BaseID = "Beast.GhoulLOW" }, { BaseID = "Beast.Ghoul", StartingResourceMin = 125 }, { BaseID = "Beast.GhoulHIGH", StartingResourceMin = 175 }]
 	},
 	{
 		ID = "Beast.Lindwurms",
-		UnitDefs = [{ ID = "Beast.Lindwurm" }]
+		UnitDefs = [{ BaseID = "Beast.Lindwurm" }]
 	},
 	{
 		ID = "Beast.Unholds",
-		UnitDefs = [{ ID = "Beast.Unhold" }]
+		UnitDefs = [{ BaseID = "Beast.Unhold" }]
 	},
 	{
 		ID = "Beast.UnholdsFrost",
-		UnitDefs = [{ ID = "Beast.UnholdFrost" }]
+		UnitDefs = [{ BaseID = "Beast.UnholdFrost" }]
 	},
 	{
 		ID = "Beast.UnholdsBog",
-		UnitDefs = [{ ID = "Beast.UnholdBog" }]
+		UnitDefs = [{ BaseID = "Beast.UnholdBog" }]
 	},
 	{
 		ID = "Beast.Spiders",
-		UnitDefs = [{ ID = "Beast.Spider" }]
+		UnitDefs = [{ BaseID = "Beast.Spider" }]
 	},
 	{
 		ID = "Beast.Alps",
-		UnitDefs = [{ ID = "Beast.Alp" }]
+		UnitDefs = [{ BaseID = "Beast.Alp" }]
 	},
 	{
 		ID = "Beast.Schrats",
-		UnitDefs = [{ ID = "Beast.Schrat" }]
+		UnitDefs = [{ BaseID = "Beast.Schrat" }]
 	},
 	// Vanilla Kraken skipped at this point
 	{
 		ID = "Beast.Hyenas",
-		UnitDefs = [{ ID = "Beast.Hyena" }, { ID = "Beast.HyenaHIGH" }]
+		UnitDefs = [{ BaseID = "Beast.Hyena" }, { BaseID = "Beast.HyenaHIGH" }]
 	},
 	{
 		ID = "Beast.Serpents",
-		UnitDefs = [{ ID = "Beast.Serpent" }]
+		UnitDefs = [{ BaseID = "Beast.Serpent" }]
 	},
 	{
 		ID = "Beast.SandGolems",
-		UnitDefs = [{ ID = "Beast.SandGolem" }, { ID = "Beast.SandGolemMEDIUM" }, { ID = "Beast.SandGolemHIGH" }]
+		UnitDefs = [{ BaseID = "Beast.SandGolem" }, { BaseID = "Beast.SandGolemMEDIUM" }, { BaseID = "Beast.SandGolemHIGH" }]
 	},
 
 // Mixed Beasts
 	{
 		ID = "Beast.HexenNoBodyguards",
-		UnitDefs = [{ ID = "Beast.Hexe" }]
+		UnitDefs = [{ BaseID = "Beast.Hexe" }]
 	},
 	{
 		ID = "Beast.HexenWithBodyguards",
-		UnitDefs = [{ ID = "Beast.Hexe" }, { ID = "Beast.HexeOneSpider" }, { ID = "Beast.HexeTwoSpider" }, { ID = "Beast.HexeOneDirewolf" }, { ID = "Beast.HexeTwoDirewolf" }]
+		UnitDefs = [{ BaseID = "Beast.Hexe" }, { BaseID = "Beast.HexeOneSpider" }, { BaseID = "Beast.HexeTwoSpider" }, { BaseID = "Beast.HexeOneDirewolf" }, { BaseID = "Beast.HexeTwoDirewolf" }]
 	},
 	{
 		ID = "Beast.HexenNoSpiders",
-		UnitDefs = [{ ID = "Beast.Hexe" }, { ID = "Beast.HexeOneDirewolf" }, { ID = "Beast.HexeTwoDirewolf" }]
+		UnitDefs = [{ BaseID = "Beast.Hexe" }, { BaseID = "Beast.HexeOneDirewolf" }, { BaseID = "Beast.HexeTwoDirewolf" }]
 	},
 	{
 		ID = "Beast.HexenBandits",    // Spawn in HexenFights
-		UnitDefs = [{ ID = "Bandit.Raider" }]
+		UnitDefs = [{ BaseID = "Bandit.Raider" }]
 	},
 	{
 		ID = "Beast.HexenBanditsRanged",    // Spawn in HexenFights. In Vanilla they only ever spawn a single marksman alongside several raiders. Never more
-		UnitDefs = [{ ID = "Bandit.Marksman" }]
+		UnitDefs = [{ BaseID = "Bandit.Marksman" }]
 	},
 
 // Bodyguards
 	{
 		ID = "Beast.SpiderBodyguards",
-		UnitDefs = [{ ID = "Beast.SpiderBodyguard" }]
+		UnitDefs = [{ BaseID = "Beast.SpiderBodyguard" }]
 	},
 	{
 		ID = "Beast.DirewolfBodyguards",
-		UnitDefs = [{ ID = "Beast.DirewolfBodyguard" }]
+		UnitDefs = [{ BaseID = "Beast.DirewolfBodyguard" }]
 	}
 ]
 

--- a/mod_dynamic_spawns/data/unitblocks/goblin_blocks.nut
+++ b/mod_dynamic_spawns/data/unitblocks/goblin_blocks.nut
@@ -3,26 +3,26 @@ local unitBlocks = [
 		ID = "Goblin.Frontline",
 		UnitDefs =
 		[
-			{ ID = "Goblin.SkirmisherLOW" },
-			{ ID = "Goblin.Skirmisher" }
+			{ BaseID = "Goblin.SkirmisherLOW" },
+			{ BaseID = "Goblin.Skirmisher" }
 		]
 	},
 	{
 		ID = "Goblin.Ranged",
 		UnitDefs = [
-			{ ID = "Goblin.AmbusherLOW" },
-			{ ID = "Goblin.Ambusher" }
+			{ BaseID = "Goblin.AmbusherLOW" },
+			{ BaseID = "Goblin.Ambusher" }
 		]
 	},
 	{
 		ID = "Goblin.Flank",
-		UnitDefs = [{ ID = "Goblin.Wolfrider" }]
+		UnitDefs = [{ BaseID = "Goblin.Wolfrider" }]
 	},
 	{
 		ID = "Goblin.Boss",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { ID = "Goblin.Overseer" }],
-			[1, { ID = "Goblin.Shaman" }]
+			[1, { BaseID = "Goblin.Overseer" }],
+			[1, { BaseID = "Goblin.Shaman" }]
 		])
 	}
 ]

--- a/mod_dynamic_spawns/data/unitblocks/greenskin_blocks.nut
+++ b/mod_dynamic_spawns/data/unitblocks/greenskin_blocks.nut
@@ -2,8 +2,8 @@ local unitBlocks = [
 	{
 		ID = "Greenskin.GoblinsFoot",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { ID = "Goblin.Skirmisher" }],
-			[1, { ID = "Goblin.Ambusher" }]
+			[1, { BaseID = "Goblin.Skirmisher" }],
+			[1, { BaseID = "Goblin.Ambusher" }]
 		])
 	}
 ]

--- a/mod_dynamic_spawns/data/unitblocks/human_blocks.nut
+++ b/mod_dynamic_spawns/data/unitblocks/human_blocks.nut
@@ -1,82 +1,82 @@
 local unitBlocks = [
 	{
 		ID = "Mercenary.Frontline",
-		UnitDefs = [{ ID = "Human.MercenaryLOW" }, { ID = "Human.Mercenary" }]
+		UnitDefs = [{ BaseID = "Human.MercenaryLOW" }, { BaseID = "Human.Mercenary" }]
 	},
 	{
 		ID = "Mercenary.Ranged",
-		UnitDefs = [{ ID = "Human.MercenaryRanged" }]
+		UnitDefs = [{ BaseID = "Human.MercenaryRanged" }]
 	},
 	{
 		ID = "Mercenary.Elite",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { ID = "Human.MasterArcher" }],
-			[1, { ID = "Human.HedgeKnight" }],
-			[1, { ID = "Human.Swordmaster" }]
+			[1, { BaseID = "Human.MasterArcher" }],
+			[1, { BaseID = "Human.HedgeKnight" }],
+			[1, { BaseID = "Human.Swordmaster" }]
 		]),
 		StartingResourceMin = 286	// In Vanilla MasterArcher appear in a group of 286 cost
 	},
 	{
 		ID = "Human.BountyHunter",
-		UnitDefs = [{ ID = "Human.BountyHunter" }]
+		UnitDefs = [{ BaseID = "Human.BountyHunter" }]
 	},
 	{
 		ID = "Human.BountyHunterRanged",
-		UnitDefs = [{ ID = "Human.BountyHunterRanged" }]
+		UnitDefs = [{ BaseID = "Human.BountyHunterRanged" }]
 	},
 	{
 		ID = "Human.Wardogs",
-		UnitDefs = [{ ID = "Human.Wardog" }]
+		UnitDefs = [{ BaseID = "Human.Wardog" }]
 	},
 	{
 		ID = "Human.Slaves",
-		UnitDefs = [{ ID = "Human.Slave" }]
+		UnitDefs = [{ BaseID = "Human.Slave" }]
 	},
 
 // Civilians
 	{
 		ID = "Human.CultistAmbush",
-		UnitDefs = [{ ID = "Human.CultistAmbush" }]
+		UnitDefs = [{ BaseID = "Human.CultistAmbush" }]
 	},
 	{
 		ID = "Human.Peasants",
-		UnitDefs = [{ ID = "Human.Peasant" }]
+		UnitDefs = [{ BaseID = "Human.Peasant" }]
 	},
 	{
 		ID = "Human.SouthernPeasants",
-		UnitDefs = [{ ID = "Human.SouthernPeasant" }]
+		UnitDefs = [{ BaseID = "Human.SouthernPeasant" }]
 	},
 	{
 		ID = "Human.PeasantsArmed",
-		UnitDefs = [{ ID = "Human.PeasantArmed" }]
+		UnitDefs = [{ BaseID = "Human.PeasantArmed" }]
 	},
 
 // Caravans
 	{
 		ID = "Human.CaravanDonkeys",
-		UnitDefs = [{ ID = "Human.CaravanDonkey" }]
+		UnitDefs = [{ BaseID = "Human.CaravanDonkey" }]
 	},
 	{
 		ID = "Human.CaravanHands",
-		UnitDefs = [{ ID = "Human.CaravanHand" }]
+		UnitDefs = [{ BaseID = "Human.CaravanHand" }]
 	},
 	{
 		ID = "Human.CaravanGuards",
-		UnitDefs = [{ ID = "Human.CaravanGuard" }, { ID = "Human.Mercenary" }]		// In Vanilla they also allow ranged mercenaries here
+		UnitDefs = [{ BaseID = "Human.CaravanGuard" }, { BaseID = "Human.Mercenary" }]		// In Vanilla they also allow ranged mercenaries here
 	},
 
 // Militia
 	{
 		ID = "Human.MilitiaFrontline",
-		UnitDefs = [{ ID = "Human.Militia" }, { ID = "Human.MilitiaVeteran" }]
+		UnitDefs = [{ BaseID = "Human.Militia" }, { BaseID = "Human.MilitiaVeteran" }]
 	},
 	{
 		ID = "Human.MilitiaRanged",
-		UnitDefs = [{ ID = "Human.MilitiaRanged" }]
+		UnitDefs = [{ BaseID = "Human.MilitiaRanged" }]
 	},
 	{
 		ID = "Human.MilitiaCaptain",
-		UnitDefs = [{ ID = "Human.MilitiaCaptain" }],
+		UnitDefs = [{ BaseID = "Human.MilitiaCaptain" }],
 		StartingResourceMin = 144	// In Vanilla they appear in a group of 144 cost
 	}
 ]

--- a/mod_dynamic_spawns/data/unitblocks/noble_blocks.nut
+++ b/mod_dynamic_spawns/data/unitblocks/noble_blocks.nut
@@ -1,35 +1,35 @@
 local unitBlocks = [
 	{
 		ID = "Noble.Frontline",
-		UnitDefs = [{ ID = "Noble.Footman" }]
+		UnitDefs = [{ BaseID = "Noble.Footman" }]
 	},
 	{
 		ID = "Noble.Backline",
-		UnitDefs = [{ ID = "Noble.Billman" }]
+		UnitDefs = [{ BaseID = "Noble.Billman" }]
 	},
 	{
 		ID = "Noble.Ranged",
-		UnitDefs = [{ ID = "Noble.Arbalester" }]
+		UnitDefs = [{ BaseID = "Noble.Arbalester" }]
 	},
 	{
 		ID = "Noble.Flank",
-		UnitDefs = [{ ID = "Noble.ArmoredWardog" }]
+		UnitDefs = [{ BaseID = "Noble.ArmoredWardog" }]
 	},
 	{
 		ID = "Noble.Support",
-		UnitDefs = [{ ID = "Noble.StandardBearer" }],
+		UnitDefs = [{ BaseID = "Noble.StandardBearer" }],
 		StartingResourceMin = 200	// In Vanilla they appear in a group of 240 cost
 	},
 	{
 		ID = "Noble.Officer",
-		UnitDefs = [{ ID = "Noble.Sergeant" }],
+		UnitDefs = [{ BaseID = "Noble.Sergeant" }],
 		StartingResourceMin = 200	// In Vanilla they appear in a group of 235 cost in noble caravans
 	},
 	{
 		ID = "Noble.Elite",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { ID = "Noble.Zweihander" }],
-			[1, { ID = "Noble.Knight" }]
+			[1, { BaseID = "Noble.Zweihander" }],
+			[1, { BaseID = "Noble.Knight" }]
 		]),
 		StartingResourceMin = 325	// In Vanilla they appear in a group of 235 cost in noble caravans
 	},
@@ -37,7 +37,7 @@ local unitBlocks = [
 // Caravan
 	{
 		ID = "Noble.Donkeys",
-		UnitDefs = [{ ID = "Noble.CaravanDonkey" }]
+		UnitDefs = [{ BaseID = "Noble.CaravanDonkey" }]
 	}
 ]
 

--- a/mod_dynamic_spawns/data/unitblocks/nomad_blocks.nut
+++ b/mod_dynamic_spawns/data/unitblocks/nomad_blocks.nut
@@ -1,23 +1,23 @@
 local unitBlocks = [
 	{
 		ID = "Nomad.Frontline",
-		UnitDefs = [{ ID = "Nomad.Cutthroat" }, { ID = "Nomad.Outlaw" }]
+		UnitDefs = [{ BaseID = "Nomad.Cutthroat" }, { BaseID = "Nomad.Outlaw" }]
 	},
 	{
 		ID = "Nomad.Ranged",
-		UnitDefs = [{ ID = "Nomad.Slinger" }, { ID = "Nomad.Archer" }]
+		UnitDefs = [{ BaseID = "Nomad.Slinger" }, { BaseID = "Nomad.Archer" }]
 	},
 	{
 		ID = "Nomad.Leader",
-		UnitDefs = [{ ID = "Nomad.Leader" }],
+		UnitDefs = [{ BaseID = "Nomad.Leader" }],
 		StartingResourceMin = 170	// In Vanilla they appear in a group of 170 cost
 	},
 	{
 		ID = "Nomad.Elite",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { ID = "Nomad.Executioner" }],
-			[1, { ID = "Nomad.DesertStalker" }],
-			[1, { ID = "Nomad.DesertDevil" }]
+			[1, { BaseID = "Nomad.Executioner" }],
+			[1, { BaseID = "Nomad.DesertStalker" }],
+			[1, { BaseID = "Nomad.DesertDevil" }]
 		]),
 		StartingResourceMin = 350	// In Vanilla Executioner appear in a group of 350 cost
 	}

--- a/mod_dynamic_spawns/data/unitblocks/orc_blocks.nut
+++ b/mod_dynamic_spawns/data/unitblocks/orc_blocks.nut
@@ -1,19 +1,19 @@
 local unitBlocks = [
 	{
 		ID = "Orc.Young",
-		UnitDefs = [{ ID = "Orc.YoungLOW" }, { ID = "Orc.Young" }]
+		UnitDefs = [{ BaseID = "Orc.YoungLOW" }, { BaseID = "Orc.Young" }]
 	},
 	{
 		ID = "Orc.Warrior",
-		UnitDefs = [{ ID = "Orc.WarriorLOW" }, { ID = "Orc.Warrior" }]
+		UnitDefs = [{ BaseID = "Orc.WarriorLOW" }, { BaseID = "Orc.Warrior" }]
 	},
 	{
 		ID = "Orc.Berserker",
-		UnitDefs = [{ ID = "Orc.Berserker" }]
+		UnitDefs = [{ BaseID = "Orc.Berserker" }]
 	},
 	{
 		ID = "Orc.Boss",
-		UnitDefs = [{ ID = "Orc.Warlord" }],
+		UnitDefs = [{ BaseID = "Orc.Warlord" }],
 	}
 ]
 

--- a/mod_dynamic_spawns/data/unitblocks/scourge_blocks.nut
+++ b/mod_dynamic_spawns/data/unitblocks/scourge_blocks.nut
@@ -2,10 +2,10 @@ local unitBlocks = [
 	{
 		ID = "Scourge.Boss",
 		UnitDefs = ::MSU.Class.WeightedContainer([
-			[1, { ID = "Undead.SkeletonPriestH" }],
-			[1, { ID = "Undead.SkeletonPriestHH" }],
-			[1, { ID = "Undead.NecromancerYK" }],
-			[1, { ID = "Undead.NecromancerKK" }]
+			[1, { BaseID = "Undead.SkeletonPriestH" }],
+			[1, { BaseID = "Undead.SkeletonPriestHH" }],
+			[1, { BaseID = "Undead.NecromancerYK" }],
+			[1, { BaseID = "Undead.NecromancerKK" }]
 		])
 	},
 ]

--- a/mod_dynamic_spawns/data/unitblocks/southern_blocks.nut
+++ b/mod_dynamic_spawns/data/unitblocks/southern_blocks.nut
@@ -1,48 +1,48 @@
 local unitBlocks = [
 	{
 		ID = "Southern.Frontline",
-		//UnitDefs = [{ ID = "Conscript" }, { ID = "Conscript++" }]
-		UnitDefs = [{ ID = "Southern.Conscript" }]
+		//UnitDefs = [{ BaseID = "Conscript" }, { BaseID = "Conscript++" }]
+		UnitDefs = [{ BaseID = "Southern.Conscript" }]
 	},
 	{
 		ID = "Southern.Backline",
-		//UnitDefs = [{ ID = "Conscript_Polearm" }, { ID = "Conscript_Polearm++" }]
-		UnitDefs = [{ ID = "Southern.Conscript_Polearm" }]
+		//UnitDefs = [{ BaseID = "Conscript_Polearm" }, { BaseID = "Conscript_Polearm++" }]
+		UnitDefs = [{ BaseID = "Southern.Conscript_Polearm" }]
 	},
 	{
 		ID = "Southern.Assassins",
-		// UnitDefs = [{ ID = "Assassin" }, { ID = "Assassin++" }]
-		UnitDefs = [{ ID = "Southern.Assassin" }]
+		// UnitDefs = [{ BaseID = "Assassin" }, { BaseID = "Assassin++" }]
+		UnitDefs = [{ BaseID = "Southern.Assassin" }]
 	},
 	{
 		ID = "Southern.Officers",
-		//UnitDefs = [{ ID = "Officer" }, { ID = "Officer++" }]
-		UnitDefs = [{ ID = "Southern.Officer" }],
+		//UnitDefs = [{ BaseID = "Officer" }, { BaseID = "Officer++" }]
+		UnitDefs = [{ BaseID = "Southern.Officer" }],
 		StartingResourceMin = 250	// In Vanilla they appear in a group of 250 cost
 	},
 	{
 		ID = "Southern.Ranged",
-		//UnitDefs = [{ ID = "Gunner" }, { ID = "Gunner++" }]
-		UnitDefs = [{ ID = "Southern.Gunner" }]
+		//UnitDefs = [{ BaseID = "Gunner" }, { BaseID = "Gunner++" }]
+		UnitDefs = [{ BaseID = "Southern.Gunner" }]
 	},
 	{
 		ID = "Southern.Siege",
-		UnitDefs = [{ ID = "Southern.Mortar" }],
+		UnitDefs = [{ BaseID = "Southern.Mortar" }],
 		StartingResourceMin = 340	// In Vanilla they appear in a group of 340 cost
 	},
 	{
 		ID = "Southern.Engineer",
-		UnitDefs = [{ ID = "Southern.Engineer" }]
+		UnitDefs = [{ BaseID = "Southern.Engineer" }]
 	},
 	{
 		ID = "Southern.Slaves",
-		UnitDefs = [{ ID = "Southern.Slave" }]
+		UnitDefs = [{ BaseID = "Southern.Slave" }]
 	},
 
 // Caravan
 	{
 		ID = "Southern.CaravanDonkeys",
-		UnitDefs = [{ ID = "Southern.CaravanDonkey" }]
+		UnitDefs = [{ BaseID = "Southern.CaravanDonkey" }]
 	}
 ]
 

--- a/mod_dynamic_spawns/data/unitblocks/undead_blocks.nut
+++ b/mod_dynamic_spawns/data/unitblocks/undead_blocks.nut
@@ -2,36 +2,36 @@ local unitBlocks = [
 	{
 		ID = "Undead.Frontline",
 		UnitDefs = [
-			{ ID = "Undead.SkeletonLight" },
-			{ ID = "Undead.SkeletonMedium", StartingResourceMin = 125 },
-			{ ID = "Undead.SkeletonHeavy", StartingResourceMin = 175 }
+			{ BaseID = "Undead.SkeletonLight" },
+			{ BaseID = "Undead.SkeletonMedium", StartingResourceMin = 125 },
+			{ BaseID = "Undead.SkeletonHeavy", StartingResourceMin = 175 }
 		]
 	},
 	{
 		ID = "Undead.Backline",
 		UnitDefs = [
-			{ ID = "Undead.SkeletonMediumPolearm", StartingResourceMin = 125 },
-			{ ID = "Undead.SkeletonHeavyPolearm", StartingResourceMin = 175 }
+			{ BaseID = "Undead.SkeletonMediumPolearm", StartingResourceMin = 125 },
+			{ BaseID = "Undead.SkeletonHeavyPolearm", StartingResourceMin = 175 }
 		]
 	},
 	{
 		ID = "Undead.Boss",
 		UnitDefs = [
-			{ ID = "Undead.SkeletonPriestH" },
-			{ ID = "Undead.SkeletonPriestHH" }
+			{ BaseID = "Undead.SkeletonPriestH" },
+			{ BaseID = "Undead.SkeletonPriestHH" }
 		]
 	},
 	{
 		ID = "Undead.SkeletonHeavyBodyguard",
 		UnitDefs = [
-			{ ID = "Undead.SkeletonHeavyBodyguard" }
+			{ BaseID = "Undead.SkeletonHeavyBodyguard" }
 		]
 	},
 	{
 		ID = "Undead.Vampire",
 		UnitDefs = [
-			{ ID = "Undead.VampireLOW" },
-			{ ID = "Undead.Vampire" }
+			{ BaseID = "Undead.VampireLOW" },
+			{ BaseID = "Undead.Vampire" }
 		]
 	}
 ]

--- a/mod_dynamic_spawns/data/unitblocks/zombie_blocks.nut
+++ b/mod_dynamic_spawns/data/unitblocks/zombie_blocks.nut
@@ -1,49 +1,49 @@
 local unitBlocks = [
 	{
 		ID = "Zombie.Frontline",
-		UnitDefs = [{ ID = "Undead.Zombie" }, { ID = "Undead.ZombieYeoman" }, { ID = "Undead.FallenHero" }]
+		UnitDefs = [{ BaseID = "Undead.Zombie" }, { BaseID = "Undead.ZombieYeoman" }, { BaseID = "Undead.FallenHero" }]
 	},
 	{
 		ID = "Zombie.Light",
-		UnitDefs = [{ ID = "Undead.Zombie" }]
+		UnitDefs = [{ BaseID = "Undead.Zombie" }]
 	},
 	{
 		ID = "Zombie.Elite",
-		UnitDefs = [{ ID = "Undead.FallenHero" }]
+		UnitDefs = [{ BaseID = "Undead.FallenHero" }]
 	},
 	{
 		ID = "Zombie.Southern",
-		UnitDefs = [{ ID = "Undead.ZombieNomad" }]
+		UnitDefs = [{ BaseID = "Undead.ZombieNomad" }]
 	},
 	{
 		ID = "Zombie.Necromancer",
-		UnitDefs = [{ ID = "Undead.Necromancer" }]
+		UnitDefs = [{ BaseID = "Undead.Necromancer" }]
 	},
 	{
 		ID = "Zombie.NecromancerWithBodyguards",
 		UnitDefs = [
-			{ ID = "Undead.NecromancerY" },
-			{ ID = "Undead.NecromancerK" },
-			{ ID = "Undead.NecromancerYK" },
-			{ ID = "Undead.NecromancerKK" }
+			{ BaseID = "Undead.NecromancerY" },
+			{ BaseID = "Undead.NecromancerK" },
+			{ BaseID = "Undead.NecromancerYK" },
+			{ BaseID = "Undead.NecromancerKK" }
 		]
 	},
 	{
 		ID = "Zombie.NecromancerWithNomads",
 		UnitDefs = [
-			{ ID = "Undead.NecromancerN" },
-			{ ID = "Undead.NecromancerNN" },
-			{ ID = "Undead.NecromancerNNN" }
+			{ BaseID = "Undead.NecromancerN" },
+			{ BaseID = "Undead.NecromancerNN" },
+			{ BaseID = "Undead.NecromancerNNN" }
 		]
 	},
 	{
 		ID = "Zombie.Ghost",
-		UnitDefs = [{ ID = "Undead.Ghost" }]
+		UnitDefs = [{ BaseID = "Undead.Ghost" }]
 	},
 	{
 		ID = "Zombie.ZombieNomadBodyguard",
 		UnitDefs = [
-			{ ID = "Undead.ZombieNomadBodyguard" }
+			{ BaseID = "Undead.ZombieNomadBodyguard" }
 		]
 	}
 ]

--- a/mod_dynamic_spawns/data/units/undead_units.nut
+++ b/mod_dynamic_spawns/data/units/undead_units.nut
@@ -69,21 +69,21 @@ local units = [
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 12,
-		SubPartyDef = { ID = "SubPartyNomad", HardMin = 1, HardMax = 1 }
+		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 1, HardMax = 1 }
 	},
 	{
 		ID = "Undead.NecromancerNN",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 12 + 12,
-		SubPartyDef = { ID = "SubPartyNomad", HardMin = 2, HardMax = 2 }
+		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 2, HardMax = 2 }
 	},
 	{
 		ID = "Undead.NecromancerNNN",
 		Troop = "Necromancer",
 		Figure = ["figure_necromancer_01", "figure_necromancer_02"],
 		Cost = 30 + 12 + 12 + 12,
-		SubPartyDef = { ID = "SubPartyNomad", HardMin = 3, HardMax = 3 }
+		SubPartyDef = { BaseID = "SubPartyNomad", HardMin = 3, HardMax = 3 }
 	}
 
 // Bodyguards for Necromancer


### PR DESCRIPTION
This is necessary for multiple reasons:
- Makes it clear that we are declaring that we want to base on another def, and are not trying to set the ID of this def.
- Allows you to have defs with their own unique IDs which are based on other defs (might be important for party variants).

Only the changes to the `spawnable.nut` and `config.nut` files are the ones that change behavior. The other commit is a replacement of `ID` with `BaseID` in the `data`.