### PR TITLE
feat: implement darxo spawn/upgrade policy

### DIFF
--- a/mod_dynamic_spawns/classes/spawn_process.nut
+++ b/mod_dynamic_spawns/classes/spawn_process.nut
@@ -362,6 +362,7 @@
 		this.SpawnInfo[_unitBlockID].Units[_unitID].Count += _count;
 		this.SpawnInfo[_unitBlockID].Total += _count;
 		this.UnitCount += _count;
+		return this.UnitCount;
 	}
 
 	function decrementUnit( _unitID, _unitBlockID, _count = 1 )
@@ -369,6 +370,7 @@
 		this.SpawnInfo[_unitBlockID].Units[_unitID].Count -= _count;
 		this.SpawnInfo[_unitBlockID].Total -= _count;
 		this.UnitCount -= _count;
+		return this.UnitCount;
 	}
 
 	// Returns 'True' if we should keep doing another spawn/upgrade cycle in this spawn_process


### PR DESCRIPTION
This PR implements the following two rules:
- A UnitBlock can only spawn the weakest already present Unit
- A UnitBlock will only upgrade the weakest already present Unit

Those rules are implemented by the following changes in the code:
- When the last unit of a type is upgraded, it is deleted from the block during this SpawnProcess
- When trying to upgrade, only the weakest available unit is checked for. If that can't upgrade then this block can't upgrade

### Todo:
- Gate these changes behind a bool setting so that they can be tried around with in praxis



I did a handful of test generations and it looks like the changes work as I envision them.