### PR TITLE
fix: apply tier width only to units that can spawn and fix its logic

### DIFF
--- a/mod_dynamic_spawns/classes/unit_block.nut
+++ b/mod_dynamic_spawns/classes/unit_block.nut
@@ -3,7 +3,7 @@
 // - It will have no type other than Units as its DynamicSpawnables
 ::DynamicSpawns.Class.UnitBlock <- class extends ::DynamicSpawns.Class.Spawnable
 {
-	TierWidth = 9999; // Specifies the maximum number of tiers that can simultaneously have spawned units
+	TierWidth = 9999; // Specifies the maximum spread of tiers that can simultaneously have spawned units
 	__WeightedDynamicSpawnables = null;
 
 	function init()

--- a/mod_dynamic_spawns/classes/unit_block.nut
+++ b/mod_dynamic_spawns/classes/unit_block.nut
@@ -3,7 +3,7 @@
 // - It will have no type other than Units as its DynamicSpawnables
 ::DynamicSpawns.Class.UnitBlock <- class extends ::DynamicSpawns.Class.Spawnable
 {
-	TierWidth = 2; // Specifies the maximum number of tiers that can simultaneously have spawned units
+	TierWidth = 9999; // Specifies the maximum number of tiers that can simultaneously have spawned units
 	__WeightedDynamicSpawnables = null;
 
 	function init()

--- a/mod_dynamic_spawns/classes/unit_block.nut
+++ b/mod_dynamic_spawns/classes/unit_block.nut
@@ -118,6 +118,9 @@
 			if (spawnables.len() == 0)
 				return null;
 
+			// Returns true if all the units at and above "my index + this.TierWidth" have no units spawned yet.
+			// Because we check units from index 0 onwards and if any higher unit beyond the TierWidth already
+			// has units spawned, then we should not spawn this unit as it would violate the TierWidth.
 			local function satisfiesTierWidth( _idx )
 			{
 				for (local i = _idx + this.TierWidth; i < spawnables.len(); i++)

--- a/mod_dynamic_spawns/classes/unit_block.nut
+++ b/mod_dynamic_spawns/classes/unit_block.nut
@@ -114,14 +114,23 @@
 		}
 		else
 		{
-			local function satisfiesTierWidth( _index )
+			local spawnables = this.__DynamicSpawnables.filter(@(_, _unit) _unit.canSpawn());
+			if (spawnables.len() == 0)
+				return null;
+
+			local function satisfiesTierWidth( _idx )
 			{
-				_index += this.TierWidth;
-				return _index >= this.__DynamicSpawnables.len() || this.__DynamicSpawnables[_index].getTotal() == 0;
+				for (local i = _idx + this.TierWidth; i < spawnables.len(); i++)
+				{
+					if (spawnables[i].getTotal() != 0)
+						return false;
+				}
+				return true;
 			}
-			foreach (i, unit in this.__DynamicSpawnables)
+
+			foreach (i, unit in spawnables)
 			{
-				if (satisfiesTierWidth(i) && unit.canSpawn())
+				if (satisfiesTierWidth(i))
 				{
 					return unit;
 				}


### PR DESCRIPTION
This fixes two problems:
- The situation where the only tier that would satisfy the TierWidth is the one that has canSpawn() == false, resulting in the unit block ending up with a single tier present. With the fix, now it will spawn the next tier that canSpawn.
- `satisfyTierWidth` only checking current + TierWidth tier for being 0 instead of all tiers at that point or above being 0.

TierWidth is now practically unlimited by default (set to 9999) instead of 2 and designers must define custom TierWidth for unit blocks where they want a custom one.

This approach has a caveat that if, for some reason, a certain block cannot spawn e.g. due to violating its HardMin, HardMax or RatioMin, RatioMax etc. then TierWidth will be violated, as now it only applies to spawnables that `canSpawn`. The point is that the two things i.e. `TierWidth` and `canSpawn` are mutually opposed to one another and one must be preferentially violated at a certain point in favor of the other, otherwise the spawn process terminates prematurely if neither of the two conditions can be satisfied. It makes more sense to preferentially allow `TierWidth` to be violated as it is consistent with our approach that conditions of spawnables at lower level i.e. Unit are preferential to the conditions of spawnables at higher level i.e. Unit Block. There was discussion on this in Discord in [this thread](https://discord.com/channels/996482927531671692/1351881925316317214).