### PR TITLE
fix: hardmin not forcing unit block spawns through getHardMin

### DIFF
--- a/mod_dynamic_spawns/classes/party.nut
+++ b/mod_dynamic_spawns/classes/party.nut
@@ -242,10 +242,11 @@
 		{
 			if (_spawn && spawnable.canSpawn())
 			{
-				if (spawnable.satisfiesRatioMin() == false)
+				if (spawnable.satisfiesRatioMin() == false || spawnable.getHardMin() > spawnable.getTotal())
 				{
+					// We want to force a spawn that is below its RatioMin or which is below its HardMin
 					this.__ForcedSpawnable = spawnable;
-					return; // Early return for performance because we want to force a spawn that is below its RatioMin
+					return; 	// Early return for performance as we found a force-spawn
 				}
 				local weight = spawnable.getSpawnWeight();
 				if (weight != 0)


### PR DESCRIPTION
Currently HardMin is only used to
- spawn something while ignoring available resources

What it does not yet do is to prioritize spawning this UnitBlock using this value, over any other choice.
If a UnitBlock defines a HardMin for itself, then me as the designer always wants to have that many units from that Block spawn in the party guaranteed.
But currently the HardMin only takes effect, if that UnitBlock is randomly chosen, considering all other eligable UnitBlocks.

This PR grants HardMin the same ability of RatioMin, in that it can cause a ForceSpawn of a UnitBlock