### PR TITLE
fix: sort units in unit blocks using a stable sort algorithm

### DIFF
--- a/mod_dynamic_spawns/classes/unit_block.nut
+++ b/mod_dynamic_spawns/classes/unit_block.nut
@@ -54,7 +54,7 @@
 
 	function sort()
 	{
-		this.__DynamicSpawnables.sort(@(a, b) a.getCost() <=> b.getCost());
+		::DynamicSpawns.__stableSort(this.__DynamicSpawnables, @(a, b) a.getCost() <=> b.getCost());
 	}
 
 	function spawnUnit()

--- a/mod_dynamic_spawns/config.nut
+++ b/mod_dynamic_spawns/config.nut
@@ -119,10 +119,10 @@
 // This feature is planned to be implemented in MSU but until that happens we've implemented a private version of it here.
 ::DynamicSpawns.__stableSort <- function( _array, _compareFunc = null )
 {
-	if (_array.len() <= 1)
+	local len = _array.len();
+	if (len <= 1)
 		return _array;
 
-	local len = _array.len();
 	for (local i = 1; i < len; i++)
 	{
 		local key = _array[i];

--- a/mod_dynamic_spawns/config.nut
+++ b/mod_dynamic_spawns/config.nut
@@ -112,3 +112,30 @@
 		return ret.init();
 	}
 }
+
+// Unlike squirrel array.sort, this preserves the order of equal members and also returns the array at the end.
+// Uses Insertion Sort algorithm. Merge Sort is slow in squirrel even for large arrays (even len 1000 array is ~1000% slower than Insertion Sort).
+// A hybrid of Insertion and Merge is also considerably slower than pure Insertion (~700% slower for 1000 len array).
+// This feature is planned to be implemented in MSU but until that happens we've implemented a private version of it here.
+::DynamicSpawns.__stableSort <- function( _array, _compareFunc = null )
+{
+	if (_array.len() <= 1)
+		return _array;
+
+	local len = _array.len();
+	for (local i = 1; i < len; i++)
+	{
+		local key = _array[i];
+		local j = i - 1;
+
+		while (j >= 0 && (_compareFunc ? _compareFunc(_array[j], key) > 0 : _array[j] > key))
+		{
+			_array[j + 1] = _array[j];
+			j--;
+		}
+
+		_array[j + 1] = key;
+	}
+
+	return _array;
+}


### PR DESCRIPTION
Once MSU has this feature then our private stableSort function can be removed and we can use the MSU one instead.