### PR TITLE
Fix upgrading algorithm

### DIFF
--- a/mod_dynamic_spawns/classes/spawnable.nut
+++ b/mod_dynamic_spawns/classes/spawnable.nut
@@ -195,13 +195,23 @@
 		return ret;
 	}
 
+	// Will this spawnable remain within the RatioMax if it were to spawn 1 more unit and parent total were to go up by 1
 	function isWithinRatioMax( _total = null )
 	{
-		local referencedTotal = ::Math.max(this.getParentSpawnable().getTotal() + 1, this.getParentSpawnable().getHardMin());
+		local referencedTotal = ::Math.max(this.getParentSpawnable().getTotal(), this.getParentSpawnable().getHardMin()) + 1;
 		local total = _total == null ? this.getTotal() : _total;
-		return total < ::Math.round(referencedTotal * this.getRatioMax());
+		return total + 1 <= ::Math.round(referencedTotal * this.getRatioMax());
 	}
 
+	// Does this spawnable satisfy its RatioMax with its current/given total
+	function satisfiesRatioMax( _total = null )
+	{
+		local referencedTotal = ::Math.max(this.getParentSpawnable().getTotal(), this.getParentSpawnable().getHardMin());
+		local total = _total == null ? this.getTotal() : _total;
+		return total <= ::Math.round(referencedTotal * this.getRatioMax());
+	}
+
+	// Does this spawnable satisfy its RatioMin with its current/given total
 	function satisfiesRatioMin( _total = null )
 	{
 		local ratio = this.getRatioMin();
@@ -222,19 +232,9 @@
 	function getSpawnWeight()
 	{
 		// Weighted-Spawns: All Spawnables that won't surpass their RatioMax if they were to get the next spawn, compete against each other for a random spawn
-		local referencedTotal = ::Math.max(this.getParentSpawnable().getTotal() + 1, this.getParentSpawnable().getHardMin());
-		local myTotal = this.getTotal();
-		local ratioMax = this.getRatioMax();
-		local weight = ratioMax - myTotal / referencedTotal.tofloat();
-		if (weight < 0)
-		{
-			if (::DynamicSpawns.Const.DetailedLogging)
-			{
-				::logError(format("Spawnable %s in party %s got a negative spawn weight of %f (RatioMax: %f, MyTotal: %i, ReferencedTotal: %i)", this.getLogName(), this.getTopParty().getLogName(), weight, ratioMax, myTotal, referencedTotal));
-			}
-			weight = 0;
-		}
-		return weight;
+		local referencedTotal = ::Math.max(this.getParentSpawnable().getTotal(), this.getParentSpawnable().getHardMin()) + 1;
+		local afterSpawnRatio = (this.getTotal() + 1) / referencedTotal.tofloat();
+		return ::Math.maxf(0.0, this.getRatioMax() - afterSpawnRatio);
 	}
 
 	function getUpgradeWeight()

--- a/mod_dynamic_spawns/classes/unit.nut
+++ b/mod_dynamic_spawns/classes/unit.nut
@@ -7,11 +7,29 @@
 	Cost = 1.0;
 
 	__Instances = null; // Each spawn of this unit is kept as an instance here. This is for being able to spawn/despawn individual instances which may vary due to spawns from their __StaticSpawnables
+	__DespawnIdx = null;
 
 	function init()
 	{
 		this.__Instances = [];
 		return base.init();
+	}
+
+	function chooseDespawn( _force = false )
+	{
+		if (this.__DespawnIdx == null || _force)
+		{
+			this.__DespawnIdx = ::Math.rand(0, this.__Instances.len() - 1);
+		}
+	}
+
+	function getDespawnInstance()
+	{
+		if (this.__DespawnIdx == null)
+			this.chooseDespawn();
+
+		if (this.__DespawnIdx != null)
+			return this.__Instances[this.__DespawnIdx];
 	}
 
 	function spawn()
@@ -40,7 +58,10 @@
 
 	function despawn()
 	{
-		local spawn = this.__Instances.remove(::Math.rand(0, this.__Instances.len() - 1));
+		this.chooseDespawn();
+		local spawn = this.__Instances.remove(this.__DespawnIdx);
+		this.__DespawnIdx = null;
+
 		this.getParty().addResources(spawn.getWorth());
 		if (::DynamicSpawns.Const.DetailedLogging)
 		{

--- a/mod_dynamic_spawns/classes/unit_block.nut
+++ b/mod_dynamic_spawns/classes/unit_block.nut
@@ -86,22 +86,28 @@
 		// Ignore the highest tier
 		for (local i = 0; i < this.__DynamicSpawnables.len() - 1 && tiers < this.TierWidth - 1; i++)
 		{
-			local unit = this.__DynamicSpawnables[i];
-			local count = unit.getTotal();
+			local oldUnit = this.__DynamicSpawnables[i];
+			local count = oldUnit.getTotal();
 			if (count == 0)
 				continue;
 
 			// Upgrading will reduce this unit's count by 1. So we need to ensure that that won't violate its RatioMin or HardMin
 			local predictedCount = count - 1;
-			if (!unit.satisfiesRatioMin(predictedCount) || predictedCount < unit.getHardMin())
+			if (!oldUnit.satisfiesRatioMin(predictedCount) || predictedCount < oldUnit.getHardMin())
 				continue;
 
 			tiers++;
 			for (local j = i + 1; j < this.__DynamicSpawnables.len(); j++)	// for loop because the next very unitType could have some requirements (like playerstrength) preventing spawn
 			{
-				if (this.__DynamicSpawnables[j].canSpawn(unit.getCost()))
+				local newUnit = this.__DynamicSpawnables[j];
+				if (!newUnit.satisfiesRatioMax(newUnit.getTotal() + 1))
+					continue;
+
+				oldUnit.chooseDespawn();
+
+				if (newUnit.canSpawn(oldUnit.getDespawnInstance().getWorth()))
 				{
-					choices.add({Unit = unit, UpgradeUnit = this.__DynamicSpawnables[j]}, unit.getUpgradeWeight());
+					choices.add({Unit = oldUnit, UpgradeUnit = newUnit}, oldUnit.getUpgradeWeight());
 					break;	// We are only interested in the closest possible upgrade path, not all of them
 				}
 			}


### PR DESCRIPTION
The main thing being fixed here is to consider the `worth` of the despawning unit during upgrading instead of only considering its `cost` when determining whether the upgrade is affordable.

While fixing it I also found that the `isWithinRatioMax` and `getSpawnWeight` functions logic could be improved. That is the first `feat` commit which also adds a separate function `satisfiesRatioMax` which is relevant for usage in the next `fix` commit.