### PR TITLE
feat!: add associated world entity to party

### DIFF
--- a/mod_dynamic_spawns/classes/party.nut
+++ b/mod_dynamic_spawns/classes/party.nut
@@ -314,6 +314,8 @@
 		this.__Resources = this.__StartingResources;
 	}
 
+	// This can be null if the party was spawned without a world party defined e.g. testing or scripted combat.
+	// Therefore, one should always do a null check before doing further operations on the returned value.
 	function getWorldEntity()
 	{
 		return this.__WorldEntity;

--- a/mod_dynamic_spawns/classes/party.nut
+++ b/mod_dynamic_spawns/classes/party.nut
@@ -13,7 +13,7 @@
 	__Resources = 0;
 	__StartingResources = 0;
 
-	__IsLocation = false;
+	__WorldEntity = null;
 
 	__SpawnAffordables = null;
 	__UpgradeAffordables = null;
@@ -314,9 +314,14 @@
 		this.__Resources = this.__StartingResources;
 	}
 
-	function isLocation()
+	function getWorldEntity()
 	{
-		return this.__IsLocation;
+		return this.__WorldEntity;
+	}
+
+	function setWorldEntity( _entity )
+	{
+		this.__WorldEntity = _entity;
 	}
 
 	function getUpgradeFactor()

--- a/mod_dynamic_spawns/hooks/config/world_entity_common.nut
+++ b/mod_dynamic_spawns/hooks/config/world_entity_common.nut
@@ -9,7 +9,7 @@ local assignTroops = ::Const.World.Common.assignTroops;
 {
 	_resources *= _weightMode == this.WeightMode.Weakest ? 0.7 : ::MSU.Math.randf(0.7, 1.0); // This accounts for vanilla choosing a random party composition allowing for picking slightly weaker as well
 
-	local dynamicParty = ::DynamicSpawns.Static.retrieveDynamicParty(_partyList, _resources);
+	local dynamicParty = ::DynamicSpawns.Static.retrieveDynamicParty(_partyList, _resources, _worldParty);
 	if (dynamicParty != null)
 	{
 		dynamicParty.spawn(_resources);
@@ -49,7 +49,7 @@ local addUnitsToCombat = ::Const.World.Common.addUnitsToCombat;
 ::Const.World.Common.addUnitsToCombat = function( _into, _partyList, _resources, _faction, _minibossify = 0 )
 {
 	_resources *= ::MSU.Math.randf(0.7, 1.0); // This accounts for vanilla choosing a random party composition allowing for picking slightly weaker as well
-	local dynamicParty = ::DynamicSpawns.Static.retrieveDynamicParty(_partyList, _resources);
+	local dynamicParty = ::DynamicSpawns.Static.retrieveDynamicParty(_partyList, _resources, _into);
 	if (dynamicParty != null)
 	{
 		dynamicParty.spawn(_resources);

--- a/mod_dynamic_spawns/hooks/config/world_entity_common.nut
+++ b/mod_dynamic_spawns/hooks/config/world_entity_common.nut
@@ -49,7 +49,7 @@ local addUnitsToCombat = ::Const.World.Common.addUnitsToCombat;
 ::Const.World.Common.addUnitsToCombat = function( _into, _partyList, _resources, _faction, _minibossify = 0 )
 {
 	_resources *= ::MSU.Math.randf(0.7, 1.0); // This accounts for vanilla choosing a random party composition allowing for picking slightly weaker as well
-	local dynamicParty = ::DynamicSpawns.Static.retrieveDynamicParty(_partyList, _resources, _into);
+	local dynamicParty = ::DynamicSpawns.Static.retrieveDynamicParty(_partyList, _resources); // no world entity to pass here
 	if (dynamicParty != null)
 	{
 		dynamicParty.spawn(_resources);

--- a/mod_dynamic_spawns/hooks/contracts/contract.nut
+++ b/mod_dynamic_spawns/hooks/contracts/contract.nut
@@ -7,10 +7,9 @@
 		// This accounts for vanilla choosing a random party composition allowing for picking slightly weaker as well
 		_resources *= ::MSU.Math.randf(0.7, 1.0);
 
-		local dynamicParty = ::DynamicSpawns.Static.retrieveDynamicParty(_party, _resources);
+		local dynamicParty = ::DynamicSpawns.Static.retrieveDynamicParty(_party, _resources, _worldParty);
 		if (dynamicParty != null)
 		{
-			dynamicParty.__IsLocation = _worldParty.isLocation();
 			dynamicParty.spawn(_resources);
 
 			_party = [

--- a/mod_dynamic_spawns/hooks/entity/world/location.nut
+++ b/mod_dynamic_spawns/hooks/entity/world/location.nut
@@ -21,7 +21,7 @@
 		// This accounts for vanilla choosing a random party composition allowing for picking slightly weaker as well
 		resources *= ::MSU.Math.randf(0.75, 1.0);
 
-		local dynamicParty = ::DynamicSpawns.Static.retrieveDynamicParty(this.m.DefenderSpawnList, resources);
+		local dynamicParty = ::DynamicSpawns.Static.retrieveDynamicParty(this.m.DefenderSpawnList, resources, this);
 		if (dynamicParty != null)
 		{
 			this.m.Troops = [];		// Whatever was in this camp before is getting wiped
@@ -35,7 +35,6 @@
 				this.m.DefenderSpawnDay = ::World.getTime().Days;
 			}
 
-			dynamicParty.__IsLocation = true; // TODO: Not so happy with this, should think of something better
 			// The above calculations are a copy of vanilla code
 			foreach (troop in dynamicParty.spawn(resources).getTroops())
 			{

--- a/mod_dynamic_spawns/static.nut
+++ b/mod_dynamic_spawns/static.nut
@@ -9,13 +9,18 @@
  *
  * @Return DSF-Party object if one exists for the given vanilla party list; null if none was set for it
  */
-::DynamicSpawns.Static.retrieveDynamicParty <- function( _vanillaPartyList, _resources = null )
+::DynamicSpawns.Static.retrieveDynamicParty <- function( _vanillaPartyList, _resources = null, _worldEntity = null )
 {
 	if (typeof _vanillaPartyList != "array") return null;
 	if (_vanillaPartyList.len() == 0) return null;
 	if (!("DynamicSpawnsPartyID" in _vanillaPartyList[0])) return null;
 
-	return this.getRegisteredPartyVariant(_vanillaPartyList[0].DynamicSpawnsPartyID, _resources);
+	local ret = this.getRegisteredPartyVariant(_vanillaPartyList[0].DynamicSpawnsPartyID, _resources);
+	if (ret != null)
+	{
+		ret.setWorldEntity(_worldEntity);
+	}
+	return ret;
 }
 
 /** Return a dynamic party definition given a vanilla party definition


### PR DESCRIPTION
Breaking change as it removes `isLocation()` function. Now to check for location you must use `getWorldEntity() != null && getWorldEntity().isLocation()`.